### PR TITLE
Moved LUTs to be external to the module.

### DIFF
--- a/TestBenches/TrackletEngine_test.cpp
+++ b/TestBenches/TrackletEngine_test.cpp
@@ -1,5 +1,8 @@
 // TrackletEngine test bench
 #include "TrackletEngineTop.h"
+#include "TrackletEngine_ptcut.h"
+#include "TrackletEngine_stubptinnercut.h"
+#include "TrackletEngine_stubptoutercut.h"
 #include "StubPairMemory.hh"
 #include "VMStubTEInnerMemory.hh"
 #include "VMStubTEOuterMemory.hh"
@@ -39,6 +42,13 @@ int main(){
   assert(fin_vmstubsouter.good());
   assert(fin_stubpairs.good());
 
+  ap_uint<1> pttable[32];
+  ap_uint<1> bendinnertable[256];
+  ap_uint<1> bendoutertable[256];
+
+  readPtTable<TE::L1L2, TE::E18, TE::C17, 32>(pttable);
+  readBendInnerTable<TE::L1L2, TE::E18, TE::C17, 256>(bendinnertable);
+  readBendOuterTable<TE::L1L2, TE::E18, TE::C17, 256>(bendoutertable);
 
   // loop over events
   for (int ievt = 0; ievt < nevents; ++ievt) {
@@ -53,7 +63,7 @@ int main(){
 
 
     // Unit Under Test
-    TrackletEngineTop(bx, inputvmstubsinner, inputvmstubsouter, outputstubpairs);
+    TrackletEngineTop(bx, inputvmstubsinner, inputvmstubsouter, pttable, bendinnertable, bendoutertable, outputstubpairs);
     
     // compare calculated outputs with those read from emulation printout
     err_count += compareMemWithFile<StubPairMemory>(outputstubpairs,fin_stubpairs,ievt,"StubPair");

--- a/TrackletAlgorithm/TrackletEngine.h
+++ b/TrackletAlgorithm/TrackletEngine.h
@@ -36,12 +36,6 @@ enum phireg {
 
 }//namespace TE
 
-
-// functions to read in pt cut and stub bend cut tables
-#include "TrackletEngine_ptcut.h"
-#include "TrackletEngine_stubptinnercut.h"
-#include "TrackletEngine_stubptoutercut.h"
-
 //----------------------------
 // Tracklet Engine main code
 //============================
@@ -51,16 +45,10 @@ void TrackletEngine(
 		    const ap_uint<3> bx,
 		    const VMStubTEInnerMemory<innertype>& instubinnerdata,
 		    const VMStubTEOuterMemory<outertype>& instubouterdata,
+                    const ap_uint<1> pttable[ptdepth],
+                    const ap_uint<1> bendinnertable[stubptinnerdepth],
+                    const ap_uint<1> bendoutertable[stubptouterdepth],
 		    StubPairMemory& outstubpair) {
-
-  ap_uint<1> pttable[ptdepth];
-  readPtTable<seed, innerphi, outerphi, ptdepth>(pttable);
-
-  ap_uint<1> bendinnertable[stubptinnerdepth];
-  readBendInnerTable<seed, innerphi, outerphi, stubptinnerdepth>(bendinnertable);
-
-  ap_uint<1> bendoutertable[stubptouterdepth];
-  readBendOuterTable<seed, innerphi, outerphi, stubptouterdepth>(bendoutertable);
 
   int nstubpairs = 0;
 #pragma HLS dependence variable=nstubpairs intra WAR true

--- a/TrackletAlgorithm/TrackletEngine.h
+++ b/TrackletAlgorithm/TrackletEngine.h
@@ -39,8 +39,8 @@ enum phireg {
 //----------------------------
 // Tracklet Engine main code
 //============================
-template<int seed, int innerphi, int outerphi, int innertype, int outertype,
-         unsigned int ptdepth, unsigned int stubptinnerdepth, unsigned int stubptouterdepth>
+template<int innertype, int outertype, unsigned int ptdepth,
+  unsigned int stubptinnerdepth, unsigned int stubptouterdepth>
 void TrackletEngine(
 		    const ap_uint<3> bx,
 		    const VMStubTEInnerMemory<innertype>& instubinnerdata,

--- a/TrackletAlgorithm/TrackletEngineTop.cpp
+++ b/TrackletAlgorithm/TrackletEngineTop.cpp
@@ -10,6 +10,9 @@ void TrackletEngineTop(const BXType bx,
 {
 #pragma HLS resource variable=instubinnerdata.get_mem() latency=2
 #pragma HLS resource variable=instubouterdata.get_mem() latency=2
+#pragma HLS resource variable=pttable latency=2
+#pragma HLS resource variable=bendinnertable latency=2
+#pragma HLS resource variable=bendoutertable latency=2
   // !!! currently handles TE_L1PHIE18_L2PHIC17 only !!!
   TE_L1PHIE18_L2PHIC17: TrackletEngine<TE::L1L2, TE::E18, TE::C17, BARRELPS, BARRELPS, 32, 256, 256>
 			(bx, instubinnerdata, instubouterdata, pttable, bendinnertable, bendoutertable, outstubpair);

--- a/TrackletAlgorithm/TrackletEngineTop.cpp
+++ b/TrackletAlgorithm/TrackletEngineTop.cpp
@@ -13,7 +13,6 @@ void TrackletEngineTop(const BXType bx,
 #pragma HLS resource variable=pttable latency=2
 #pragma HLS resource variable=bendinnertable latency=2
 #pragma HLS resource variable=bendoutertable latency=2
-  // !!! currently handles TE_L1PHIE18_L2PHIC17 only !!!
-  TE_L1PHIE18_L2PHIC17: TrackletEngine<TE::L1L2, TE::E18, TE::C17, BARRELPS, BARRELPS, 32, 256, 256>
-			(bx, instubinnerdata, instubouterdata, pttable, bendinnertable, bendoutertable, outstubpair);
+  TrackletEngine<BARRELPS, BARRELPS, 32, 256, 256>
+  (bx, instubinnerdata, instubouterdata, pttable, bendinnertable, bendoutertable, outstubpair);
 }

--- a/TrackletAlgorithm/TrackletEngineTop.cpp
+++ b/TrackletAlgorithm/TrackletEngineTop.cpp
@@ -3,11 +3,14 @@
 void TrackletEngineTop(const BXType bx,
                        const VMStubTEInnerMemory<BARRELPS>& instubinnerdata,
                        const VMStubTEOuterMemory<BARRELPS>& instubouterdata,
+                       const ap_uint<1> pttable[32],
+                       const ap_uint<1> bendinnertable[256],
+                       const ap_uint<1> bendoutertable[256],
                        StubPairMemory& outstubpair)
 {
 #pragma HLS resource variable=instubinnerdata.get_mem() latency=2
 #pragma HLS resource variable=instubouterdata.get_mem() latency=2
   // !!! currently handles TE_L1PHIE18_L2PHIC17 only !!!
   TE_L1PHIE18_L2PHIC17: TrackletEngine<TE::L1L2, TE::E18, TE::C17, BARRELPS, BARRELPS, 32, 256, 256>
-			(bx, instubinnerdata, instubouterdata, outstubpair);
+			(bx, instubinnerdata, instubouterdata, pttable, bendinnertable, bendoutertable, outstubpair);
 }

--- a/TrackletAlgorithm/TrackletEngineTop.h
+++ b/TrackletAlgorithm/TrackletEngineTop.h
@@ -3,7 +3,6 @@
 
 #include "TrackletEngine.h"
 
-// !!! currently handles TE_L1PHIE18_L2PHIC17 only !!!
 void TrackletEngineTop(const BXType bx,
                        const VMStubTEInnerMemory<BARRELPS>& instubinnerdata,
                        const VMStubTEOuterMemory<BARRELPS>& instubouterdata,

--- a/TrackletAlgorithm/TrackletEngineTop.h
+++ b/TrackletAlgorithm/TrackletEngineTop.h
@@ -7,6 +7,9 @@
 void TrackletEngineTop(const BXType bx,
                        const VMStubTEInnerMemory<BARRELPS>& instubinnerdata,
                        const VMStubTEOuterMemory<BARRELPS>& instubouterdata,
+                       const ap_uint<1> pttable[32],
+                       const ap_uint<1> bendinnertable[256],
+                       const ap_uint<1> bendoutertable[256],
                        StubPairMemory& outstubpair);
 
 #endif


### PR DESCRIPTION
This PR is meant to start a discussion about moving the lookup tables out of certain processing modules in order to greatly reduce the time required to run C-synthesis and export IP cores. There are 579 TrackletEngines in the current project, so I started with it, since we have a lot to gain here in terms of reducing this time.

The `pttable`, `bendinnertable`, and `bendoutertable` are now just memory interfaces on the TE IP core. The actual tables will exist as ROMs in the EMP payload, which will be wired to the appropriate TE by the project generation scripts. For example, here is what the `pttable` ports look like:
| RTL ports | Dir | Bits | Protocol | Source object | C type |
| --- | --- | --- | --- | --- | --- |
| pttable_V_address0 | out | 5 | ap_memory | pttable_V | array |
| pttable_V_ce0 | out | 1 | ap_memory | pttable_V | array |
| pttable_V_q0 | in | 1 | ap_memory | pttable_V | array |

I think we will still need a few different IP cores for the TE because the bit widths vary for different types of VM stubs (PS, 2S, disk, etc.). But going from 579 IP cores to three or four will still save us a lot of CPU-hours.

The TE still passes C-simulation, is still pipelined with II=1, and still passes C/RTL cosimulation. The resource utilization and timing estimates have also barely changed (the previously-internal lookup tables are quite small and were implemented as distributed ROMs):

### HLS estimates (VU7P @ 250 MHz)
| | Internal LUTs | External LUTs |
| --- | --- | --- |
| BRAM_18K | 0 | 0 |
| DPS48E | 0 | 0 |
| FF | 891 | 898 |
| LUT | 5554 | 5545 |
| URAM | 0 | 0 |
| Clock period | 6.035 ns | 6.035 ns |

### Post-implementation estimates (VU7P @ 250 MHz)
| | Internal LUTs | External LUTs |
| --- | --- | --- |
| CLB | 170 | 158 |
| LUT | 761 | 726 |
| FF | 613 | 613 |
| DSP | 0 | 0 |
| BRAM | 0 | 0 |
| SRL | 0 | 7 |
| URAM | 0 | 0 |
| Clock period | 3.158 ns | 3.160 ns |