### PR TITLE
A working version of the MatchEngine Code

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -4,7 +4,7 @@ env:
 
 on: # Controls when the action will run.
   push: # Please add your branch down here if wanted. A build will be triggerd for each push.
-    branches: [master, feat_actions, fw_synch_update] 
+    branches: [master, feat_actions, fw_synch_update, MEUpdate] 
 jobs: # A workflow run is made up of one or more jobs that can run sequentially or in parallel
   hls-build: # Job name
     runs-on: self-hosted # The type of runner that the job will run on
@@ -32,7 +32,7 @@ jobs: # A workflow run is made up of one or more jobs that can run sequentially 
       uses: actions/upload-artifact@v1
       with:
         name: ME
-        path: project/matchengine/solution1/syn/report/MatchEngineTopL3_csynth.rpt
+        path: project/matchengine/solution1/syn/report/MatchEngineTop_csynth.rpt
     - name: PR # Script name
       run: |
         cd project

--- a/TrackletAlgorithm/AllProjectionMemory.h
+++ b/TrackletAlgorithm/AllProjectionMemory.h
@@ -127,6 +127,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return AllProjectionBase<AProjType>::kAllProjectionSize;}
+  
   AllProjectionData raw() const {return data_;}
   
   AProjTCID getTCID() const {

--- a/TrackletAlgorithm/AllStubMemory.h
+++ b/TrackletAlgorithm/AllStubMemory.h
@@ -137,6 +137,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return AllStubBase<ASType>::kAllStubSize;}
+
   AllStubData raw() const {return data_; }
 
   ASR getR() const {

--- a/TrackletAlgorithm/CandidateMatchMemory.h
+++ b/TrackletAlgorithm/CandidateMatchMemory.h
@@ -50,6 +50,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return kCandidateMatchSize;}
+  
   CandidateMatchData raw() const {return data_;}
   
   CMProjIndex getProjIndex() const {

--- a/TrackletAlgorithm/FullMatchMemory.h
+++ b/TrackletAlgorithm/FullMatchMemory.h
@@ -102,6 +102,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return FullMatchBase<FMType>::kFullMatchSize;}
+
   FullMatchData raw() const {return data_;}
 
   FMTCID getTCID() const {

--- a/TrackletAlgorithm/InputStubMemory.h
+++ b/TrackletAlgorithm/InputStubMemory.h
@@ -130,6 +130,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return InputStubBase<ISType>::kInputStubSize;}
+
   InputStubData raw() const {return data_; }
 
   ISR getR() const {

--- a/TrackletAlgorithm/MatchEngine.cpp
+++ b/TrackletAlgorithm/MatchEngine.cpp
@@ -1,0 +1,224 @@
+#include "MatchEngine.h"
+
+void readTable(bool table[LSIZE]){
+	bool tmp[LSIZE]=
+	#if LAYER == 1
+#include "../emData/ME/ME_L3PHIC20/METable_L1.tab"
+	#elif LAYER == 2
+#include "../emData/ME/ME_L3PHIC20/METable_L2.tab"
+	#elif LAYER == 3
+#include "../emData/ME/ME_L3PHIC20/METable_L3.tab"
+	#elif LAYER == 4
+#include "../emData/ME/ME_L3PHIC20/METable_L4.tab"
+	#elif LAYER == 5
+#include "../emData/ME/ME_L3PHIC20/METable_L5.tab"
+	#elif LAYER == 6
+#include "../emData/ME/ME_L3PHIC20/METable_L6.tab"
+	#else
+{};
+	#endif
+
+	for (int i=0;i<LSIZE;i++){
+		table[i]=tmp[i];
+	}
+}
+
+//template<int L, regionType VMSMEType>
+template<int L, int VMSMEType, int VMPMEType>
+void MatchEngine(const BXType bx, BXType& bx_o,
+				 const VMStubMEMemory<VMSMEType>& inputStubData,
+				 const VMProjectionMemory<VMPMEType>& inputProjectionData,
+				 CandidateMatchMemory& outputCandidateMatch) {
+	//
+	//Initialize table for bend-rinv consistency
+	//
+	//bool table[(L<4)?256:512]; //FIXME Need to figure out how to replace 256 with meaningful const.
+	bool table[LSIZE];
+	readTable(table);
+
+	outputCandidateMatch.clear();
+
+	//
+	// Set up a FIFO based on a circular buffer structure.
+	// Projection memory is read and if projections points to nonempty zbin for the stubs it is stored on this buffer.
+	// The projection reading will stop if buffer is full and continue after the buffer is drained.
+	// Each element consists of
+	//   * kNBits_BufferAddr is the number of bits to handle buffer index (i.e. buffer size will be 1<<kNBits_BufferAddr).
+	//   * kBufferDataSize is the size of each element in the buffer. The element data consists of, in order of MSB to LSB:
+	//       [# of stubs in z-bin][projection data][index of z-bin][z-bin flag]
+	//
+	ap_uint<kBufferDataSize> projectionBuffer[1<<kNBits_BufferAddr];
+	#pragma HLS ARRAY_PARTITION variable=projectionBuffer complete dim=0
+	ap_uint<kNBits_BufferAddr> head_writeindex = 0;	// handles current buffer index for writing
+	ap_uint<kNBits_BufferAddr> tail_readindex = 0;	// handles current buffer index for reading
+
+	// The next projection to read, the number of projections and flag if we have more projections to read
+	ap_uint<kNBits_MemAddr> iprojection = 0;
+	auto const nproj = inputProjectionData.getEntries(bx);
+	bool moreProjectionsAvailable = iprojection < nproj;
+
+	// Variables for the projection
+	typename VMProjection<VMPMEType>::VMPID projindex;
+	typename VMProjection<VMPMEType>::VMPFINEZ projfinez;
+	typename VMProjection<VMPMEType>::VMPRINV projrinv;
+	ap_uint<MEBinsBits> zbin = 0;
+	int ncmatch = 0;
+	bool isPSseed;
+	bool second;
+
+	// Number of stubs for current zbin and the stub being processed on this clock
+	ap_uint<kNBits_MemAddrBinned> nstubs=0;
+	ap_uint<kNBits_MemAddrBinned> istub=0;
+	#pragma HLS dependence variable=istub intra WAR true
+
+#ifdef DEBUG
+	std::cout << "ProjectionIndex\tStubIndex\t<=== (PASS/FAIL)" << std::endl;
+#endif
+
+	// Main processing loops starts here
+	STEP_LOOP: for (ap_uint<kNBits_MemAddr> istep=0; istep<kMaxProc; istep++) {
+		#pragma HLS PIPELINE II=1
+		#pragma HLS DEPENDENCE variable=tail_readindex inter false
+
+		// Pre-fetch an element from the buffer
+		auto const qdata=projectionBuffer[tail_readindex];
+
+		// The buffer is not full if 2 slots are available as we may write stubs for up to 2 z-bins
+		ap_uint<kNBits_BufferAddr> head_writeindexplus     = head_writeindex+1;
+		ap_uint<kNBits_BufferAddr> head_writeindexplusplus = head_writeindex+2;
+		bool bufferNotFull = (head_writeindexplus!=tail_readindex) && (head_writeindexplusplus!=tail_readindex);
+
+		// The buffer is not empty when current write index and read index are different
+		// With this you have to assume the buffer will never be absolutely full
+		bool bufferNotEmpty = head_writeindex != tail_readindex;
+
+		// If we have more projections and the buffer is not full we read
+		// next projection and put in buffer if there are stubs in the 
+		// memory the to which the projection points
+		if (moreProjectionsAvailable && bufferNotFull) {
+			auto const iprojectiontmp=iprojection;
+			auto const projectiondatatmp=inputProjectionData.read_mem(bx,iprojectiontmp);
+			iprojection++;
+			moreProjectionsAvailable=iprojection<nproj;
+
+			// The first and last zbin the projection points to
+			auto const projectionzbitstmp=projectiondatatmp.getZBin();
+			ap_uint<MEBinsBits> zbinfirst=projectionzbitstmp.range(3,1);
+			ap_uint<MEBinsBits> zbinlast=zbinfirst + projectionzbitstmp.range(0,0);
+
+			// Check if there are stubs in the memory
+			auto const nstubfirst = inputStubData.getEntries(bx,zbinfirst);
+			auto const nstublast  = inputStubData.getEntries(bx,zbinlast);
+			bool savefirst = (nstubfirst != 0);
+			bool savelast  = (nstublast != 0) && projectionzbitstmp.range(0,0);
+			auto const head_writeindex_tmp=head_writeindex;
+
+			if (savefirst) {
+				ap_uint<1> zero=0;
+				ap_uint<MEBinsBits+1> tmp=zbinfirst.concat(zero);
+				ap_uint<VMProjection<PROJECTIONTYPE>::kVMProjectionSize+MEBinsBits+1> tmp2=projectiondatatmp.raw().concat(tmp);
+				projectionBuffer[head_writeindex_tmp] = nstubfirst.concat(tmp2);
+			}
+			if (savelast) {
+				ap_uint<1> one=1;
+				ap_uint<MEBinsBits+1> tmp=zbinlast.concat(one);
+				ap_uint<VMProjection<PROJECTIONTYPE>::kVMProjectionSize+MEBinsBits+1> tmp2=projectiondatatmp.raw().concat(tmp);
+				ap_uint<kNBits_BufferAddr> head_writeindex_tmp_last = head_writeindex_tmp+savefirst;
+				projectionBuffer[head_writeindex_tmp_last] = nstublast.concat(tmp2);
+			}
+#ifdef DEBUG
+			std::cout << "Writing " << savefirst+savelast << " z-bins ==> head_writeindex " << head_writeindex << "-->";
+#endif
+			head_writeindex = head_writeindex + savefirst + savelast;
+#ifdef DEBUG
+			std::cout << head_writeindex << std::endl;
+#endif
+		}
+
+		// If the buffer is not empty we have a projection that we need to process ...
+		if (bufferNotEmpty) {
+			ap_uint<kNBits_MemAddrBinned> istubtmp=istub;
+
+			//Need to read the information about the proj in the buffer
+			second=qdata.range(ME::BitLocations::kVMMESecondMSB,ME::BitLocations::kVMMESecondLSB);
+			nstubs=qdata.range(ME::BitLocations::kVMMENStubsMSB,ME::BitLocations::kVMMENStubsLSB);
+			VMProjection<PROJECTIONTYPE> data(qdata.range(ME::BitLocations::kVMMEProjectionMSB,ME::BitLocations::kVMMEProjectionLSB));
+			zbin=qdata.range(ME::BitLocations::kVMMEZBinMSB,ME::BitLocations::kVMMEZBinLSB);
+
+			projindex=data.getIndex();
+			projfinez=data.getFineZ();
+			projrinv=data.getRInv();
+			isPSseed=data.getIsPSSeed();
+
+			// Check if last stub, if so, go to next buffer entry 
+			if (istub+1 >= nstubs){
+			  istub = 0;
+			  tail_readindex++;
+			}
+			else {
+			  istub++;
+			}
+
+			// Read stub memory and extract data fields
+			auto const stubadd   = zbin.concat(istubtmp);
+			auto const stubdata  = inputStubData.read_mem(bx,stubadd);
+			auto const stubindex = stubdata.getIndex();
+			auto const stubfinez = stubdata.getFineZ();
+			auto const stubbend  = stubdata.getBend();
+
+			// Calculate fine z position
+			ap_int<VMProjectionBase<PROJECTIONTYPE>::kVMProjFineZSize+1> projfinezadj = projfinez;
+			if (second) projfinezadj = projfinezadj - 8;
+			ap_int<VMProjectionBase<PROJECTIONTYPE>::kVMProjFineZSize+1> idz          = stubfinez - projfinezadj;
+
+			// Check if stub z position consistent
+			bool pass = (isPSseed) ? (idz >= -2 && idz <= 2) : (idz >= -5 && idz <= 5);
+
+			// Check if stub bend and proj rinv consistent
+#ifdef DEBUG
+			std::cout << projindex.to_string() << "\t" << stubindex.to_string() << "\t<=== ";
+#endif
+			auto const index=projrinv.concat(stubbend);
+			if (pass && table[index]) {
+				CandidateMatch cmatch(projindex.concat(stubindex));
+				outputCandidateMatch.write_mem(bx,cmatch,ncmatch);
+				ncmatch++;
+#ifdef DEBUG
+				std::cout << "PASS -- " << ncmatch-1 << "\n";
+#endif
+			}
+#ifdef DEBUG
+			else {
+				std::cout << "FAIL" << "\n";
+			}
+			std::cout << "\ttail_readindex: " << tail_readindex << "\n"
+					  << "\thead_writeindex: " << head_writeindex << "\n"
+					  << "\tsecond: " << second << "\n"
+					  << "\tprojfinez: " << projfinez << "\n"
+					  << "\tprojfinezadj: " << projfinezadj << "\n"
+					  << "\tstubfinez: " << stubfinez << "\n"
+					  << "\tidz: " << idz.to_string() << "\n"
+					  << "\tisPSseed: " << isPSseed << "\n"
+					  << "\tpass: " << pass << "\n"
+					  << "\tindex: " << index.get().to_string() << "\n"
+					  << "\ttable[index]: " << table[index] << "\n"
+					  << "\tnstubs:" << nstubs << "\n"
+					  << "\tistub:" << istub << std::endl;
+#endif
+		}
+	}
+
+	bx_o = bx;
+}
+
+void MatchEngineTop(const BXType bx, BXType& bx_o,
+					const VMStubMEMemory<MODULETYPE>& inputStubData,
+					const VMProjectionMemory<PROJECTIONTYPE>& inputProjectionData,
+					CandidateMatchMemory& outputCandidateMatch) {
+
+#pragma HLS interface register port=bx_o
+//#pragma HLS resource variable=inputStubData->get_mem() latency=2
+//#pragma HLS resource variable=inputProjectionData->get_mem() latency=2
+
+	MatchEngine<LAYER,MODULETYPE,PROJECTIONTYPE>(bx, bx_o, inputStubData, inputProjectionData, outputCandidateMatch); 
+}

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -1,379 +1,105 @@
 #ifndef MATCHENGINE_H
 #define MATCHENGINE_H
 
+// cms-tracklet/firmware-hls Headers
 #include "Constants.h"
 #include "VMProjectionMemory.h"
-#include "CandidateMatchMemory.h"
 #include "VMStubMEMemory.h"
+#include "CandidateMatchMemory.h"
+
+// HLS Headers
 #include "hls_math.h"
+
+// STL Headers
 #include <iostream>
 #include <fstream>
 
+/////////////////////////////
+// -- PREPROCESSOR FUNCTIONS
+#define IS_REPRESENTIBLE_IN_D_BITS(D, N)                \
+   (((unsigned long) N >= (1UL << (D - 1)) && (unsigned long) N < (1UL << D)) ? D : -1)
+#define BITS_TO_REPRESENT(N)                             \
+   (N == 0 ? 1 : (31                                     \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 1, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 2, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 3, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 4, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 5, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 6, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 7, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 8, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS( 9, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(10, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(11, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(12, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(13, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(14, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(15, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(16, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(17, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(18, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(19, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(20, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(21, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(22, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(23, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(24, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(25, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(26, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(27, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(28, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(29, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(30, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(31, N)    \
+				  + IS_REPRESENTIBLE_IN_D_BITS(32, N)    \
+				  )                                      \
+	  )
+#define LAYER 3
+//Options: BARREL and DISK
+#define PROJECTIONTYPE BARREL
+#if (LAYER >= 1) && (LAYER <= 3)
+	#define MODULETYPE BARRELPS
+#elif (LAYER >= 4) && (LAYER <= 6)
+	#define MODULETYPE BARREL2S
+#endif
 
-template<int L>
-void readTable(bool table[256]){
-
-  if (L==1) {
-    bool tmp[256]=
-#include "../emData/ME/ME_L3PHIC20/METable_L1.tab"
-    for (int i=0;i<256;i++){
-      table[i]=tmp[i];
-    }
-  }
-
-  if (L==2) {
-    bool tmp[256]=
-#include "../emData/ME/ME_L3PHIC20/METable_L2.tab"
-    for (int i=0;i<256;i++){
-      table[i]=tmp[i];
-    }
-  }
-
-  if (L==3) {
-    bool tmp[256]=
-#include "../emData/ME/ME_L3PHIC20/METable_L3.tab"
-    for (int i=0;i<256;i++){
-      table[i]=tmp[i];
-    }
-  }
-
-  if (L==4) {
-    bool tmp[512]=
-#include "../emData/ME/ME_L3PHIC20/METable_L4.tab"
-    for (int i=0;i<512;i++){
-      table[i]=tmp[i];
-    }
-  }
-
-  if (L==5) {
-    bool tmp[512]=
-#include "../emData/ME/ME_L3PHIC20/METable_L5.tab"
-    for (int i=0;i<512;i++){
-      table[i]=tmp[i];
-    }
-  }
-
-  if (L==6) {
-    bool tmp[512]=
-#include "../emData/ME/ME_L3PHIC20/METable_L6.tab"
-    for (int i=0;i<512;i++){
-      table[i]=tmp[i];
-    }
-  }
-
-
-
+#define RINVSTEPS 32
+//BARRELPS=256 and BARREL2S=512
+#define LSIZE RINVSTEPS*(1<<VMStubME<MODULETYPE>::kVMSMEBendSize)
+#define BUFFERSIZE 8
+constexpr unsigned int kNBits_BufferAddr=BITS_TO_REPRESENT(BUFFERSIZE-1);
+constexpr int kBufferDataSize = 5												// number of bits for stubs array size (size of NEntryT in MemoryTemplateBinned.h)
+							  + VMProjection<PROJECTIONTYPE>::kVMProjectionSize	// projection data size
+							  + MEBinsBits										// number of bits for index of z-bin
+							  + 1;												// z-bin flag (0 => first bin, 1 => second bin)
+namespace ME {
+	enum BitLocations {
+	    // The location of the least significant bit (LSB) and most significant bit (MSB) in the ME buffer word for different fields
+	    kVMMESecondLSB = 0,
+	    kVMMESecondMSB = 0,
+	    kVMMEZBinLSB = kVMMESecondMSB + 1,
+	    kVMMEZBinMSB = kVMMEZBinLSB + MEBinsBits - 1,
+	    kVMMEProjectionLSB = kVMMEZBinMSB + 1,
+	    kVMMEProjectionMSB = kVMMEProjectionLSB + VMProjection<PROJECTIONTYPE>::kVMProjectionSize - 1,
+   	    kVMMENStubsLSB = kVMMEProjectionMSB + 1,
+	    kVMMENStubsMSB = kVMMENStubsLSB + 5 - 1
+	};
 }
 
+/////////////////////////////
+// -- MATCH ENGINE FUNCTIONS
+void readTable(bool table[LSIZE]);
 
-// There are two different implementations of the MatchEngine. 
-// By selecting 'CODEVERSION' on the line below you select which
-// implementation to use:
-// 1 - Version of the code is closest to emulation. Triple nested loop
-//     which can not be pipelined
-// 2 - Loop structure has been flattened and code modified to use 
-//     a buffer for the projections. It reaches II=1 for the loop
-//
-#define CODEVERSION 2
-
-#if CODEVERSION==2
-
-//Attempt at new version of code
-template<int L, regionType VMSMEType>
-void MatchEngine(BXType bx, BXType& bx_o,
-		 const VMStubMEMemory<VMSMEType>* instubdata,
-		 const VMProjectionMemory<BARREL>* inprojdata,
-		 CandidateMatchMemory* outcandmatch){
-
-#pragma HLS inline
-#ifndef __SYNTHESIS__
-  //Prinout of number of projections and stubs
-  std::cout << "In MatchEngine #proj ="<<std::hex<<inprojdata->getEntries(bx)<<" #stubs=";
-  for (unsigned int zbin=0;zbin<8;zbin++){
-    std::cout <<" "<<instubdata->getEntries(bx,zbin);
-  }
-  std::cout<<std::dec<<std::endl;
-#endif
-
-  //Initialize table for bend-rinv consistency
-  bool table[(L<4)?256:512]; //FIXME Need to figure out how to replace 256 with meaningful const.
-  readTable<L>(table);
-
-  outcandmatch->clear();
-
-  //Buffer of projections. Projection memory is read and if projections points
-  //to nonempty zbin for the stubs it is stored on this buffer. The buffer is 
-  //circular, and the projection reading will stop if buffer is full and continue 
-  //after the buffer is drained
-
-  constexpr unsigned int kNBitsBuffer=3;
-  constexpr int kNBits_ProjBuffer =kNBits_MemAddrBinned + VMProjectionBase<BARREL>::kVMProjectionSize + 1 +kNBits_z +1;
-
-  ap_uint<kNBitsBuffer> writeindex=0;
-  ap_uint<kNBitsBuffer> readindex=0;
-  ap_uint<kNBits_ProjBuffer> projbuffer[1<<kNBitsBuffer];  //projbuffer = nstub+projdata+finez
-#pragma HLS ARRAY_PARTITION variable=projbuffer complete dim=0
-
-  //The next projection to read, the number of projections and flag if we have
-  //more projections to read
-  ap_uint<kNBits_MemAddr> iproj=0; //counter
-  auto const nproj=inprojdata->getEntries(bx);
-  bool moreproj=iproj<nproj;
-
-  //Projection that is read from the buffer and compared to stubs  
-  ap_uint<TEBinsBits> zbin=0;
-  VMProjection<BARREL>::VMPID projindex;
-  VMProjection<BARREL>::VMPFINEZ projfinez;
-  ap_int<5> projfinezadj; //FIXME Need replace 5 with const
-  VMProjection<BARREL>::VMPRINV projrinv;
-  bool isPSseed;
-  bool second;
-
-  //Number of stubs for current zbin and the stub being processed on this clock
-  ap_uint<kNBits_MemAddrBinned> nstubs=0;
-  ap_uint<kNBits_MemAddrBinned> istub=0;
-#pragma HLS dependence variable=istub intra WAR true
-  
-// declare counter for output to CandidateMatch // !!!                                                                                                                                                       
-  int ncmatchout = 0;
-
-  //Main processing loops starts here  
-  for (ap_uint<kNBits_MemAddr> istep=0;istep<kMaxProc-8;istep++) {
-#pragma HLS PIPELINE II=1
-
-    //prefetch and calculate write pointers for buffer
-    auto const qdata=projbuffer[readindex];
-    ap_uint<kNBitsBuffer> writeindexplus=writeindex+1;
-    ap_uint<kNBitsBuffer> writeindexplusplus=writeindex+2;
-
-    //Determine if buffere is full - or near full as a projection
-    //can point to two z bins we might fill two slots in the buffer
-    bool buffernotfull=(writeindexplus!=readindex)&&(writeindexplusplus!=readindex);
-    //Determin if buffere is empty
-    bool buffernotempty=(writeindex!=readindex);
-
-    //If we have more projections and the buffer is not full we read
-    //next projection and put in buffer if there are stubs in the 
-    //memory the projection points to
-    if (moreproj&&buffernotfull){
-      auto const iprojtmp=iproj;
-      auto const projdata=inprojdata->read_mem(bx,iprojtmp);
-      auto const projzbin=projdata.getZBin();
-      iproj++;
-      moreproj=iproj<nproj;
-
-      //The first and last zbin the projection points to
-      ap_uint<TEBinsBits> zfirst=projzbin.range(3,1);
-      ap_uint<TEBinsBits> zlast=zfirst+projzbin.range(0,0);
-
-      //Check if there are stubs in the memory
-      auto const nstubfirst=instubdata->getEntries(bx,zfirst);
-      auto const  nstublast=instubdata->getEntries(bx,zlast);
-      bool savefirst=nstubfirst!=0;
-      bool savelast=nstublast!=0&&projzbin.range(0,0);
-      auto const writeindextmp=writeindex;
-
-      if (savefirst&&savelast) {
-	writeindex=writeindexplusplus;
-      } else if (savefirst||savelast) {
-	writeindex=writeindexplus;
-      }
-
-      if (savefirst) { //FIXME code needs to be cleaner
-	ap_uint<1> zero=0;
-	ap_uint<4> tmp=zfirst.concat(zero);
-	ap_uint<26> tmp2=projdata.raw().concat(tmp);
-	projbuffer[writeindextmp]=nstubfirst.concat(tmp2);
-      }
-      if (savelast) {
-	ap_uint<1> one=1;
-	ap_uint<4> tmp=zlast.concat(one);
-	ap_uint<26> tmp2=projdata.raw().concat(tmp);
-	if (savefirst) {
-	  ap_uint<kNBitsBuffer> writeindextmpplus=writeindextmp+1;
-	  projbuffer[writeindextmpplus]=nstublast.concat(tmp2);
-	} else {
-	  projbuffer[writeindextmp]=nstublast.concat(tmp2);
-	}
-      }
-    }
-
-
-    //If the buffer is not empty we have a projection that we need to 
-    //process. 
-    if (buffernotempty) {
-
-      ap_uint<kNBits_MemAddrBinned> istubtmp=istub;
-
-      //New projection
-      if (istub==0) {
-
-	//Need to read the information about the proj in the buffer
-        nstubs=qdata.range(29,26);
-	zbin=qdata.range(3,1);
-	VMProjection<BARREL> data(qdata.range(25,4));
-
-	projindex=data.getIndex();
-	projfinez=data.getFineZ();
-	projrinv=data.getRInv();
-	isPSseed=data.getIsPSSeed();
-
-	second=qdata.range(0,0);	
-
-	//Calculate fine z position
-	if (second) {
-	  projfinezadj=projfinez-8;
-	} else {
-	  projfinezadj=projfinez;
-	}
-
-	if (nstubs==1) {
-	  istub=0;
-	  readindex++;
-	} else {
-	  istub++;
-	}
-      } else {
-	//Check if last stub, if so, go to next buffer entry 
-	if (istub+1>=nstubs){
-	  istub=0;
-	  readindex++;
-	} else {
-	  istub++;
-	}
-      }
-      
-      //Read stub memory and extract data fields
-      auto const  stubadd=zbin.concat(istubtmp);
-      //typename VMStubME<VMSMEType> stubdata=instubdata->read_mem(bx,stubadd);
-      //typename VMStubME<VMSMEType>::VMSMEID stubindex=stubdata.getIndex();
-      //typename VMStubME<VMSMEType>::VMSMEFINEZ stubfinez=stubdata.getFineZ();
-      //typename VMStubME<VMSMEType>::VMSMEBEND stubbend=stubdata.getBend();
-      auto stubdata=instubdata->read_mem(bx,stubadd);
-      auto stubindex=stubdata.getIndex();
-      auto stubfinez=stubdata.getFineZ();
-      auto stubbend=stubdata.getBend();
-
-      //std::cout << "projindex stubindex "<<projindex<<" "<<stubindex<<std::endl;
-
-      //Check if stub z position consistent
-      ap_int<5> idz=stubfinez-projfinezadj;
-      bool pass;
-      if (isPSseed) {
-	pass=idz>=-2&&idz<=2;
-      } else {
-	pass=idz>=-5&&idz<=5;
-      }
-
-      //Check if stub bend and proj rinv consistent
-      auto const index=projrinv.concat(stubbend);
-      //if (pass) {
-      //	std::cout << "index "<<index<<" "<<table[index]<<std::endl;
-      //}
-      if (pass&&table[index]) {
-	CandidateMatch cmatch(projindex.concat(stubindex));
-	outcandmatch->write_mem(bx,cmatch,ncmatchout);
-	ncmatchout ++;
-      } // if(pass&&table[index])
-      
-    } // if(buffernotempty)
-
-    if (istep==kMaxProc-1-8) bx_o = bx;
-  } // for (ap_uint<kNBits_MemAddr> istep=0;istep<kMaxProc;istep++) 
-
-} // void MatchEngine()
-
-#endif
-
-
-
-#if CODEVERSION==1
-
-//
-// This version closely follows the code in the emulations. This version can
-// not be pipelined
-// This version has not been updated to be compatible with the new memory formats
-
+//template<int L, regionType VMSMEType>
+template<int L, int VMSMEType>
 void MatchEngine(const BXType bx, BXType& bx_o,
-		 const VMStubMEMemory* instubdata,
-		 const VMProjectionMemory* inprojdata,
-		 CandidateMatchMemory* outcandmatch){
+		 		 const VMStubMEMemory<VMSMEType>& inputStubData,
+		 		 const VMProjectionMemory<PROJECTIONTYPE>& inputProjectionData,
+		 		 CandidateMatchMemory& outputCandidateMatch);
 
-
-#ifndef __SYNTHESIS__
-  std::cout << "In MatchEngine #proj ="<<std::hex<<inprojdata->getEntries(bx)<<" #stubs=";
-  for (unsigned int zbin=0;zbin<8;zbin++){
-    std::cout <<" "<<instubdata->getEntries(bx,zbin);
-  }
-  std::cout<<std::dec<<std::endl;
-#endif
-
-  // Initialize the pt-bend lookup table
-  bool table[256]; //Need to figure out how to replace 256 with some 
-                   //meaning full constant
-  readTable(table);
-
-  outcandmatch->clear();
-
-  auto const nproj=inprojdata->getEntries(bx);
-
-  // declare counter for output to CandidateMatch // !!!
-  int ncmatchout = 0;
-  //Outermost loop is over the projections
-  for (ap_uint<kNBits_MemAddr> iproj=0;iproj<nproj;iproj++) {
-    //Read projection from memory and extract the elements of the projection
-    VMProjection proj=inprojdata->read_mem(bx,iproj);
-    VMProjection::VMPID projindex=proj.getIndex();
-    VMProjection::VMPZBIN projzbin=proj.getZBin();
-    VMProjection::VMPFINEZ projfinez=proj.getFineZ();
-    VMProjection::VMPRINV projrinv=proj.getRInv();
-    bool isPSseed=proj.getIsPSSeed();
-    
-    //Calculate first and last zbin that need to searched for stubs
-    ap_uint<TEBinsBits> zfirst=projzbin.range(3,1);
-    ap_uint<TEBinsBits> zlast=zfirst+projzbin.range(0,0);
-
-
-    //Loop over the zbins. There are at most two zbins that needs to be searched
-    for (ap_uint<TEBinsBits> zbin=zfirst;zbin<=zlast;zbin++){
-      ap_uint<kNBits_MemAddrBinned> nstub=instubdata->getEntries(bx,zbin);
-
-      //Loop over the stubs in the bin
-      for (ap_uint<kNBits_MemAddrBinned> istub=0;istub<nstub;istub++) {
-        //Read the stub memory and extract the elements of the projection
-        //VMStubME stubdata=instubdata->read_mem(bx,zbin.concat(istub));
-	//VMStubME::VMSMEID stubindex=stubdata.getIndex();
-	//VMStubME::VMSMEFINEZ stubfinez=stubdata.getFineZ();
-	//VMStubME::VMSMEBEND stubbend=stubdata.getBend();
-
-        auto const stubdata=instubdata->read_mem(bx,zbin.concat(istub));
-	auto const stubindex=stubdata.getIndex();
-	auto const stubfinez=stubdata.getFineZ();
-	auto const stubbend=stubdata.getBend();
-	
-	//Check is stub and projection satisfies the z cut 
-	ap_int<5> idz=stubfinez-projfinez;
-	if (zbin!=zfirst) idz+=8;
-	bool pass=hls::abs(idz)<=5;
-	if (isPSseed) {
-	  pass=hls::abs(idz)<=2;
-	}
-
-	//Use lookup table for pt-bend matchcing and if stub passes
-	//the cut save the projection-stub pair as a candidate match
-	auto const index=projrinv.concat(stubbend);
-	if (pass&&table[index]) {
-	  CandidateMatch cmatch(projindex.concat(stubindex));
-	  outcandmatch->write_mem(bx,cmatch,ncmatchout);
-	  ncmatchout ++;
-	}
-
-      }
-    }
-  }
-}
-
-#endif
-
+void MatchEngineTop(const BXType bx, BXType& bx_o,
+					const VMStubMEMemory<MODULETYPE>& inputStubData,
+					const VMProjectionMemory<PROJECTIONTYPE>& inputProjectionData,
+					CandidateMatchMemory& outputCandidateMatch);
 
 #endif

--- a/TrackletAlgorithm/MatchEngineTopL1.h
+++ b/TrackletAlgorithm/MatchEngineTopL1.h
@@ -4,9 +4,8 @@
 #include "MatchEngine.h"
 
 void MatchEngineTopL1(const ap_uint<3> bx,
-		      const VMStubMEMemory<BARRELPS>* const instubdata,
-		      const VMProjectionMemory<BARREL>* const inprojdata,
-		      CandidateMatchMemory* const outcandmatch);
-
+					  const VMStubMEMemory<BARRELPS>* const instubdata,
+					  const VMProjectionMemory<BARREL>* const inprojdata,
+					  CandidateMatchMemory* const outcandmatch);
 
 #endif

--- a/TrackletAlgorithm/MatchEngineTopL4.h
+++ b/TrackletAlgorithm/MatchEngineTopL4.h
@@ -8,5 +8,4 @@ void MatchEngineTopL4(const ap_uint<3> bx,
 		      const VMProjectionMemory<BARREL>* const inprojdata,
 		      CandidateMatchMemory* const outcandmatch);
 
-
 #endif

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -15,6 +15,7 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR>
 class MemoryTemplate
 {
 public:
+  typedef typename DataType::BitWidths BitWidths;
   typedef ap_uint<NBIT_BX> BunchXingT;
   typedef ap_uint<NBIT_ADDR+1> NEntryT;
   
@@ -133,6 +134,8 @@ public:
 	  }
 	}
   }
+
+  static constexpr int getWidth() {return DataType::getWidth();}
   
 #endif
   

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -184,6 +184,8 @@ public:
 	  }
 	}
   }
+
+  static constexpr int getWidth() {return DataType::getWidth();}
   
 #endif
   

--- a/TrackletAlgorithm/StubPairMemory.h
+++ b/TrackletAlgorithm/StubPairMemory.h
@@ -48,6 +48,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return kStubPairSize;}
+
   StubPairData raw() const {return data_;}
   
   SPInnerIndex getInnerIndex() const {

--- a/TrackletAlgorithm/TrackFitMemory.h
+++ b/TrackletAlgorithm/TrackFitMemory.h
@@ -73,6 +73,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return kTrackFitSize;}
+
   TrackFitData raw() const {return data_;}
 
   TFPT getPt() const {

--- a/TrackletAlgorithm/TrackletParameterMemory.h
+++ b/TrackletAlgorithm/TrackletParameterMemory.h
@@ -64,6 +64,8 @@ public:
   #endif
   
   // Getter
+  static constexpr int getWidth() {return kTrackletParameterSize;}
+
   TrackletParameterData raw() const {return data_;}
 
   STUBINDEX getStubIndexOuter() const {

--- a/TrackletAlgorithm/TrackletProjectionMemory.h
+++ b/TrackletAlgorithm/TrackletProjectionMemory.h
@@ -112,6 +112,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return TrackletProjectionBase<TProjType>::kTrackletProjectionSize;}
+
   TrackletProjectionData raw() const {return data_;}
 
   // TCID is a unique identifier assigned to each TC. It is a concatenation of

--- a/TrackletAlgorithm/VMProjectionMemory.h
+++ b/TrackletAlgorithm/VMProjectionMemory.h
@@ -99,6 +99,8 @@ public:
   #endif
   
   // Getter
+  static constexpr int getWidth() {return VMProjectionBase<VMProjType>::kVMProjectionSize;}
+
   VMProjData raw() const {return data_;}
   
   VMPID getIndex() const {

--- a/TrackletAlgorithm/VMStubMEMemory.h
+++ b/TrackletAlgorithm/VMStubMEMemory.h
@@ -93,6 +93,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return VMStubMEBase<VMSMEType>::kVMStubMESize;}
+
   VMStubMEData raw() const {return data_;}
 
   VMSMEID getIndex() const {

--- a/TrackletAlgorithm/VMStubTEInnerMemory.h
+++ b/TrackletAlgorithm/VMStubTEInnerMemory.h
@@ -113,6 +113,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return VMStubTEInnerBase<VMSTEIType>::kVMStubTEInnerSize;}
+
   VMStubTEInnerData raw() const {return data_;}
 
   VMSTEIID getIndex() const {

--- a/TrackletAlgorithm/VMStubTEOuterMemory.h
+++ b/TrackletAlgorithm/VMStubTEOuterMemory.h
@@ -98,6 +98,8 @@ public:
   #endif
 
   // Getter
+  static constexpr int getWidth() {return VMStubTEOuterBase<VMSTEOType>::kVMStubTEOuterSize;}
+  
   VMStubTEOuterData raw() const {return data_;}
 
   VMSTEOID getIndex() const {

--- a/project/script_ME.tcl
+++ b/project/script_ME.tcl
@@ -7,10 +7,11 @@
 open_project -reset matchengine
 
 # source files
+# Optional Flags: -DDEBUG
 set CFLAGS {-std=c++11 -I../TrackletAlgorithm}
-set_top MatchEngineTopL3
-add_files ../TrackletAlgorithm/MatchEngineTopL3.cc -cflags "$CFLAGS"
-add_files -tb ../TestBenches/MatchEngineL3_test.cpp -cflags "$CFLAGS"
+set_top MatchEngineTop
+add_files ../TrackletAlgorithm/MatchEngine.cpp -cflags "$CFLAGS"
+add_files -tb ../TestBenches/MatchEngine_test.cpp -cflags "$CFLAGS"
 
 # data files
 add_files -tb ../emData/ME/
@@ -22,9 +23,9 @@ source settings_hls.tcl
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design
-cosim_design 
+cosim_design -trace_level all -rtl verilog -verbose
 export_design -format ip_catalog
 # Adding "-flow impl" runs full Vivado implementation, providing accurate resource use numbers (very slow).
-#export_design -format ip_catalog -flow impl
+#export_design -rtl verilog -format ip_catalog -flow impl
 
 exit


### PR DESCRIPTION
This PR provides an update to the MatchEngine. This comes along with a significant reorganization of the ME code and some additional changes to make debugging easier. The code is fully templated, which allows us to easily configure it for different layers and and module types. The code has been tested and verified under the following conditions:

| Layer | csim | synth | cosim | NEvents |
|---|:---:|---|---|---|
| 1 | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul> | 100 |
| 2 | <ul><li>[ ] </li></ul> | <ul><li>[ ] </li></ul> | <ul><li>[ ] </li></ul> | -- |
| 3 | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul> | 100 |
| 4 | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul> | <ul><li>[x] </li></ul> | 100 |
| 5 | <ul><li>[ ] </li></ul> | <ul><li>[ ] </li></ul> | <ul><li>[ ] </li></ul> | -- |
| 6 | <ul><li>[ ] </li></ul> | <ul><li>[ ] </li></ul> | <ul><li>[ ] </li></ul> | -- |

<ul><li>[x] = Pass</li></ul>
<ul><li>[ ] = Untested</li></ul>