### PR TITLE
Fix common and ME specific clang-tidy warnings

### DIFF
--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -24,7 +24,7 @@ bool openDataFile(std::ifstream& file_in, const std::string& file_name)
     std::cerr << "Open of file " << file_name << " failed with error: ";
     std::cerr << std::strerror(errno);
     std::cerr << std::endl;
-    std::cerr << "running from directory " << getcwd(NULL,0) << std::endl;
+    std::cerr << "running from directory " << getcwd(nullptr,0) << std::endl;
   }
 
   return success;
@@ -64,7 +64,7 @@ std::vector<std::string> split(const std::string& s, char delimiter)
   std::istringstream sstream(s);
   
   while (getline(sstream, token, delimiter)) {
-    if (token=="") continue;
+    if (token.empty()) continue;
     tokens.push_back(token);
   }
   
@@ -92,10 +92,10 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
       return;
     } else {
       if (split(line,' ').size()==4) {
-	memory.write_mem(ievt, line.c_str(), base);	
+       memory.write_mem(ievt, line, base);
       } else {
 	const std::string datastr = split(line, ' ').back();
-	memory.write_mem(ievt, datastr.c_str(), base);
+	memory.write_mem(ievt, datastr, base);
       }
     }	
   }

--- a/TrackletAlgorithm/MatchEngine.cpp
+++ b/TrackletAlgorithm/MatchEngine.cpp
@@ -1,7 +1,7 @@
 #include "MatchEngine.h"
 
-void readTable(bool table[LSIZE]){
-	bool tmp[LSIZE]=
+void readTable(ap_uint<1> table[LSIZE]){
+	ap_uint<1> tmp[LSIZE]=
 	#if LAYER == 1
 #include "../emData/ME/ME_L3PHIC20/METable_L1.tab"
 	#elif LAYER == 2
@@ -33,7 +33,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 	//Initialize table for bend-rinv consistency
 	//
 	//bool table[(L<4)?256:512]; //FIXME Need to figure out how to replace 256 with meaningful const.
-	bool table[LSIZE];
+	ap_uint<1> table[LSIZE];
 	readTable(table);
 
 	outputCandidateMatch.clear();

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -104,6 +104,13 @@ public:
 	// std::cout << "write_mem " << data << std::endl;
 	return write_mem(ibx, data, nent);
   }
+  bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
+  {
+    DataType data(datastr.c_str(), base);
+        int nent = nentries_[ibx];
+	// std::cout << "write_mem " << data << std::endl;
+	return write_mem(ibx, data, nent);
+  }
 
   // print memory contents
   void print_data(const DataType data) const


### PR DESCRIPTION
This PR fixes some of the issues raised by the clang-tidy checks. In particular, the changes to FileReadUtility.h and MemoryTemplate.h are common to most of the projects. The changes to MatchEngine.cpp are MatchEngine specific.