### PR TITLE
remove branch before mirroring to make it work with git push --force

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,21 @@ Checks: -*,
   ,readability-redundant-string-cstr,
   ,readability-static-definition-in-anonymous-namespace,
   ,readability-uniqueptr-delete-release
-WarningsAsErrors: ''
+WarningsAsErrors: -*,
+  ,boost-use-to-string,
+  ,misc-string-compare,
+  ,misc-uniqueptr-reset-release,
+  ,modernize-deprecated-headers,
+  ,modernize-make-shared,
+  ,modernize-use-bool-literals,
+  ,modernize-use-equals-delete,
+  ,modernize-use-nullptr,
+  ,modernize-use-override,
+  ,performance-unnecessary-copy-initialization,
+  ,readability-container-size-empty,
+  ,readability-redundant-string-cstr,
+  ,readability-static-definition-in-anonymous-namespace,
+  ,readability-uniqueptr-delete-release
 HeaderFilterRegex: '../TrackletAlgorithm|../TestBenches'
 AnalyzeTemporaryDtors: false
 CheckOptions:    

--- a/.github/workflows/GitLab_CI.yml
+++ b/.github/workflows/GitLab_CI.yml
@@ -2,9 +2,9 @@ name: Mirror and run GitLab CI
 
 on: # Controls when the action will run.
   push: # Please add your branch down here if wanted. A build will be triggerd for each push.
-    branches: [feat_actions] 
+    branches: [feat_CI]
   pull_request:
-    branches: [master, feat_actions]
+    branches: [master]
     
 env:
   current_branch: 'master' # fallback branch
@@ -37,3 +37,4 @@ jobs:
         GITLAB_PROJECT_ID: "89897"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret
         CHECKOUT_BRANCH: ${{ env.current_branch }} # New non-GITHUB variable to make push and PR work
+        REMOVE_BRANCH: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages: # ---------------------------------------------------------------------
     - pwd; ls -la; #debug
     # Hard coded -config='' because the quotes do not work in the variable
     - ${CLANG_TIDY_PATH} -config='' ${CLANG_TIDY_OPTIONS} ${CLANG_TIDY_FILES} -- ${CLANG_TIDY_COMP_OPTIONS} ${CLANG_TIDY_INCLUDES}
+  allow_failure: true # to proceed with errors for now
 
 .job_template: &template_hls-build
   <<: *template_base


### PR DESCRIPTION
Changes in gitlab-mirror-and-ci-action repo:
Remove set -u to allow a check of the new variable REMOVE_BRANCH.
Check if the new variable exists and is true.
Check if the branch exists and delete it remotely.