### PR TITLE
switch to new clang-tidy version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
   VIVADO_PATH_SH: '/nfs/data41/software/Xilinx/Vivado/${VIVADO_VERSION}/settings64.sh'
-  CLANG_TIDY_PATH: '/opt/rh/llvm-toolset-7/root/bin/clang-tidy'
+  CLANG_TIDY_PATH: '/opt/rh/llvm-toolset-7.0/root/bin/clang-tidy'
   CLANG_TIDY_OPTIONS: '-format-style=file' #-config='' does not work because of the quotes; -header-filter in .clang-tidy
   CLANG_TIDY_COMP_OPTIONS: '-std=c++11 -I../TrackletAlgorithm -I../TestBenches -I/nfs/data41/software/Xilinx/Vivado/2019.2/include'
 
@@ -21,11 +21,14 @@ stages: # ---------------------------------------------------------------------
   tags:
     - xilinx-tools
   stage: quality-check
+  before_script:
+    # Needed for new tool version
+    - source /opt/rh/llvm-toolset-7.0/enable
   script:
     - cd emData
     - ./download.sh
     - cd ../project
-    - pwd; ls -la; #debug
+    - pwd; ls -la; # Debug
     # Hard coded -config='' because the quotes do not work in the variable
     - ${CLANG_TIDY_PATH} -config='' ${CLANG_TIDY_OPTIONS} ${CLANG_TIDY_FILES} -- ${CLANG_TIDY_COMP_OPTIONS} ${CLANG_TIDY_INCLUDES}
 
@@ -34,7 +37,7 @@ stages: # ---------------------------------------------------------------------
   stage: hls-build
   script:
     - cd project
-    - pwd; ls -la; #debug
+    - pwd; ls -la; # Debug
     - vivado_hls -f "script_${PROJ_NAME}.tcl"
   artifacts:
     when: on_success


### PR DESCRIPTION
**New clang-tidy version based on LLVM 7 to get a non-zero return value when a diagnostic (compiler) error occurs according to: https://github.com/cms-tracklet/firmware-hls/pull/96#issuecomment-630928864**

### Notes
#### Documentation (different version)
https://developers.redhat.com/blog/2018/07/07/yum-install-gcc7-clang/
#### Installation
```
sudo yum install centos-release-scl-rh
sudo yum --enablerepo=centos-sclo-rh-testing install llvm-toolset-7.0-clang-analyzer llvm-toolset-7.0-clang-tools-extra
source /opt/rh/llvm-toolset-7.0/enable
```
#### Test: Should return LLVM version 7.0.1
`/opt/rh/llvm-toolset-7.0/root/bin/clang-tidy -version `