### PR TITLE
Update the download script and fix some clang-tidy issues

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,6 @@ VMR-quality-check:
   <<: *template_quality-check
   variables:
     CLANG_TIDY_FILES: '../TestBenches/VMRouter_test.cpp ../TrackletAlgorithm/VMRouterTop.cc'
-  allow_failure: true
 TE-quality-check:
   <<: *template_quality-check
   variables:

--- a/TestBenches/VMRouter_test.cpp
+++ b/TestBenches/VMRouter_test.cpp
@@ -137,7 +137,7 @@ int main()
 
     // Unit Under Test
     VMRouterTop(bx,
-    		&ilink1, &ilink2, &ilink3, &ilink4, 0, 0, //&ilink4, &ilink5, &ilink6,
+		&ilink1, &ilink2, &ilink3, &ilink4, nullptr, nullptr, //&ilink4, &ilink5, &ilink6,
 		// &ilink7, &ilink8,
 			&allstub,
 		&vmstubme1, &vmstubme2, &vmstubme3, &vmstubme4,

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -13,7 +13,7 @@
 #include "VMStubMEMemory.h"
 #include "VMStubTEInnerMemory.h"
 #include "VMStubTEOuterMemory.h"
-#include <assert.h>
+#include <cassert>
 
 // I include this to get the constants. we should figure out if this is
 // the right way to go.

--- a/TrackletAlgorithm/VMRouterTop.cc
+++ b/TrackletAlgorithm/VMRouterTop.cc
@@ -32,12 +32,12 @@ void VMRouterTop(BXType bx,
 
 	// The main function
 	VMRouter<BARRELPS, BARRELPS, layer, disk, ninputs, meMask>(
-		 bx, i0, i1, i2, i3, 0, 0, //i6, i7,
+		 bx, i0, i1, i2, i3, nullptr, nullptr, //i6, i7,
 		 allStub,
-		 0, 0, 0, 0, 0, 0, 0, 0, // 0-7
-		 0, 0, 0, 0, 0, 0, 0, 0, // 8-15
-		 m0,m1,m2,m3,0, 0, 0, 0, // 16-23
-		 0, 0, 0, 0, 0, 0, 0, 0 // 24-31
+		 nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, // 0-7
+		 nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, // 8-15
+		 m0,m1,m2,m3,nullptr, nullptr, nullptr, nullptr, // 16-23
+		 nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr // 24-31
 		 );
 
 	return;

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # fw_synch_200515
-tarball_url="https://cernbox.cern.ch/index.php/s/CipX7CfTXIj1lcK/download"
+tarball_url="https://cernbox.cern.ch/index.php/s/tsxTkilHDVhnbYF/download"
 
 # The following modules will have dedicated directories of test-bench files
 # prepared for them.
@@ -16,6 +16,7 @@ declare -a processing_modules=(
   "TC_L1L2E"
   "TC_L1L2G"
   "TC_L3L4E"
+  "TC_L5L6D"
 
   # ProjectionRouter
   "PR_L3PHIC"
@@ -27,7 +28,11 @@ declare -a processing_modules=(
 
   # MatchCalculator
   "MC_L1PHIC"
+  "MC_L2PHIC"
   "MC_L3PHIC"
+  "MC_L4PHIC"
+  "MC_L5PHIC"
+  "MC_L6PHIC"
 )
 
 # If the MemPrints directory exists, assume the script has already been run,
@@ -67,4 +72,25 @@ do
   do
     find MemPrints/ -type f -regex ".*_${mem}_04\.dat$" -exec ln -s ../../{} ${target_dir}/ \;
   done
+
+  # Table linking logic specific to each module type
+  table_location="MemPrints/Tables/"
+  table_target_dir="${module_type}/tables"
+  if [[ ! -d "${table_target_dir}" ]]
+  then
+          mkdir -p ${table_target_dir}
+  fi
+
+  if [[ ${module_type} == "TC" ]]
+  then
+          layer_pair=`echo ${module} | sed "s/\(.*\)./\1/g"`
+          find ${table_location} -type f -name "${layer_pair}_*.tab" -exec ln -sf ../../{} ${table_target_dir}/ \;
+  elif [[ ${module_type} == "ME" ]]
+  then
+          layer=`echo ${module} | sed "s/.*_\(L[1-9]\).*$/\1/g"`
+          find ${table_location} -type f -name "METable_${layer}.tab" -exec ln -sf ../../{} ${table_target_dir}/ \;
+  elif [[ ${module_type} == "VMR" ]] || [[ ${module_type} == "MC" ]] || [[ ${module_type} == "TE" ]]
+  then
+          find ${table_location} -type f -name "${module}_*.tab" -exec ln -sf ../../{} ${table_target_dir}/ \;
+  fi
 done

--- a/project/script_IR.tcl
+++ b/project/script_IR.tcl
@@ -12,13 +12,13 @@ set_top InputRouter
 add_files ../TrackletAlgorithm/InputRouter.cpp -cflags "$CFLAGS"
 add_files -tb ../TestBenches/InputRouter_test.cpp -cflags "CFLAGS"
 
-# data files
-add_files -tb ../emData/IL/
-
 open_solution "solution1"
 
 # Define FPGA, clock frequency & common HLS settings.
 source settings_hls.tcl
+
+# data files
+add_files -tb ../emData/IL/
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design

--- a/project/script_MC.tcl
+++ b/project/script_MC.tcl
@@ -12,13 +12,13 @@ set_top MatchCalculatorTop
 add_files ../TrackletAlgorithm/MatchCalculatorTop.cc -cflags "$CFLAGS"
 add_files -tb ../TestBenches/MatchCalculator_test.cpp -cflags "$CFLAGS"
 
-# data files
-add_files -tb ../emData/MC/
-
 open_solution "solution1"
 
 # Define FPGA, clock frequency & common HLS settings.
 source settings_hls.tcl
+
+# data files
+add_files -tb ../emData/MC/
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design

--- a/project/script_ME.tcl
+++ b/project/script_ME.tcl
@@ -13,13 +13,13 @@ set_top MatchEngineTop
 add_files ../TrackletAlgorithm/MatchEngine.cc -cflags "$CFLAGS"
 add_files -tb ../TestBenches/MatchEngine_test.cpp -cflags "$CFLAGS"
 
-# data files
-add_files -tb ../emData/ME/
-
 open_solution "solution1"
 
 # Define FPGA, clock frequency & common HLS settings.
 source settings_hls.tcl
+
+# data files
+add_files -tb ../emData/ME/
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design

--- a/project/script_PR.tcl
+++ b/project/script_PR.tcl
@@ -12,14 +12,14 @@ set_top ProjectionRouterTop
 add_files ../TrackletAlgorithm/ProjectionRouterTop.cc -cflags "$CFLAGS"
 add_files -tb ../TestBenches/ProjectionRouter_test.cpp -cflags "$CFLAGS"
 
-# data files
-add_files -tb ../emData/PR/PR_L3PHIC/
-#add_files -tb ../emData/PR/PR_L3L4_L1PHI3/
-
 open_solution "solution1"
 
 # Define FPGA, clock frequency & common HLS settings.
 source settings_hls.tcl
+
+# data files
+add_files -tb ../emData/PR/PR_L3PHIC/
+#add_files -tb ../emData/PR/PR_L3L4_L1PHI3/
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design

--- a/project/script_TC.tcl
+++ b/project/script_TC.tcl
@@ -12,14 +12,14 @@ set_top TrackletCalculator_L1L2G
 add_files ../TrackletAlgorithm/TrackletCalculator.cc -cflags "$CFLAGS"
 add_files -tb ../TestBenches/TrackletCalculator_L1L2G_test.cpp -cflags "$CFLAGS"
 
-# data files
-add_files -tb ../emData/TC/tables/
-add_files -tb ../emData/TC/TC_L1L2G/
-
 open_solution "solution1"
 
 # Define FPGA, clock frequency & common HLS settings.
 source settings_hls.tcl
+
+# data files
+add_files -tb ../emData/TC/tables/
+add_files -tb ../emData/TC/TC_L1L2G/
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design

--- a/project/script_TE.tcl
+++ b/project/script_TE.tcl
@@ -12,13 +12,13 @@ set_top TrackletEngineTop
 add_files ../TrackletAlgorithm/TrackletEngineTop.cc -cflags "$CFLAGS"
 add_files -tb ../TestBenches/TrackletEngine_test.cpp -cflags "$CFLAGS"
 
-# data files
-add_files -tb ../emData/TE/
-
 open_solution "solution1"
 
 # Define FPGA, clock frequency & common HLS settings.
 source settings_hls.tcl
+
+# data files
+add_files -tb ../emData/TE/
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design

--- a/project/script_VMR.tcl
+++ b/project/script_VMR.tcl
@@ -12,13 +12,13 @@ set_top VMRouterTop
 add_files ../TrackletAlgorithm/VMRouterTop.cc -cflags "$CFLAGS"
 add_files -tb ../TestBenches/VMRouter_test.cpp -cflags "$CFLAGS"
 
-# data files
-add_files -tb ../emData/VMR/
-
 open_solution "solution1"
 
 # Define FPGA, clock frequency & common HLS settings.
 source settings_hls.tcl
+
+# data files
+add_files -tb ../emData/VMR/
 
 csim_design -compiler gcc -mflags "-j8"
 csynth_design


### PR DESCRIPTION
Modify the test vector tarball and the download script to make links for the needed tables rather than having real files outside the MemPrints folder. Some additional modules for the TC and VMR needed to be added to the download script in because these modules don't use preprocessor pragmas to determine which headers are needed.

Because it was a small annoyance during the testing of this change, this PR fixes some clang-tidy issues with the VMR.