### PR TITLE
MatchEngine memory paging and latency

### DIFF
--- a/TrackletAlgorithm/MatchEngine.cc
+++ b/TrackletAlgorithm/MatchEngine.cc
@@ -217,8 +217,8 @@ void MatchEngineTop(const BXType bx, BXType& bx_o,
 					CandidateMatchMemory& outputCandidateMatch) {
 
 #pragma HLS interface register port=bx_o
-//#pragma HLS resource variable=inputStubData->get_mem() latency=2
-//#pragma HLS resource variable=inputProjectionData->get_mem() latency=2
+#pragma HLS resource variable=inputStubData->get_mem() latency=2
+#pragma HLS resource variable=inputProjectionData->get_mem() latency=2
 
 	MatchEngine<LAYER,MODULETYPE,PROJECTIONTYPE>(bx, bx_o, inputStubData, inputProjectionData, outputCandidateMatch); 
 }

--- a/TrackletAlgorithm/VMStubMEMemory.h
+++ b/TrackletAlgorithm/VMStubMEMemory.h
@@ -129,6 +129,6 @@ private:
 };
 
 // Memory definition
-template<int VMSMEType> using VMStubMEMemory = MemoryTemplateBinned<VMStubME<VMSMEType>, 2, kNBits_MemAddr,3>;
+template<int VMSMEType> using VMStubMEMemory = MemoryTemplateBinned<VMStubME<VMSMEType>, 3, kNBits_MemAddr,3>;
 
 #endif


### PR DESCRIPTION
Switch from a 4 page to an 8 page stub memory. Also change the read latency of the memory to 2.