### PR TITLE
Pr arrays

### DIFF
--- a/TestBenches/ProjectionRouter_test.cpp
+++ b/TestBenches/ProjectionRouter_test.cpp
@@ -18,25 +18,11 @@ int main()
 
   ///////////////////////////
   // input memories
-  static TrackletProjectionMemory<BARRELPS> tproj1;
-  static TrackletProjectionMemory<BARRELPS> tproj2;
-  static TrackletProjectionMemory<BARRELPS> tproj3;
-  static TrackletProjectionMemory<BARRELPS> tproj4;
-  static TrackletProjectionMemory<BARRELPS> tproj5;
-  static TrackletProjectionMemory<BARRELPS> tproj6;
-  static TrackletProjectionMemory<BARRELPS> tproj7;
-  static TrackletProjectionMemory<BARRELPS> tproj8;
+  static TrackletProjectionMemory<BARRELPS> tprojarray[8];
 
   // output memories
   static AllProjectionMemory<BARRELPS> allproj;
-  static VMProjectionMemory<BARREL> vmproj1;
-  static VMProjectionMemory<BARREL> vmproj2;
-  static VMProjectionMemory<BARREL> vmproj3;
-  static VMProjectionMemory<BARREL> vmproj4;
-  static VMProjectionMemory<BARREL> vmproj5;
-  static VMProjectionMemory<BARREL> vmproj6;
-  static VMProjectionMemory<BARREL> vmproj7;
-  static VMProjectionMemory<BARREL> vmproj8;
+  static VMProjectionMemory<BARREL> vmprojarray[8];
 
   ///////////////////////////
   // open input files
@@ -119,18 +105,15 @@ int main()
     cout << "Event: " << dec << ievt << endl;
 
     // read event and write to memories
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj1, fin_tproj1, ievt);
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj2, fin_tproj2, ievt);
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj3, fin_tproj3, ievt);
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj4, fin_tproj4, ievt);
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj5, fin_tproj5, ievt);
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj6, fin_tproj6, ievt);
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj7, fin_tproj7, ievt);
-    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj8, fin_tproj8, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[0], fin_tproj1, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[1], fin_tproj2, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[2], fin_tproj3, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[3], fin_tproj4, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[4], fin_tproj5, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[5], fin_tproj6, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[6], fin_tproj7, ievt);
+    writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tprojarray[7], fin_tproj8, ievt);
 
-    TrackletProjectionMemory<BARRELPS> tprojarray[8] = {tproj1,tproj2,tproj3,tproj4,tproj5,tproj6,tproj7,tproj8};
-    VMProjectionMemory<BARREL> vmprojarray[8] = {vmproj1,vmproj2,vmproj3,vmproj4,vmproj5,vmproj6,vmproj7,vmproj8};
-    
     // bx
     BXType bx = ievt;
     BXType bx_out;

--- a/TestBenches/ProjectionRouter_test.cpp
+++ b/TestBenches/ProjectionRouter_test.cpp
@@ -129,18 +129,14 @@ int main()
     writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj8, fin_tproj8, ievt);
 
     TrackletProjectionMemory<BARRELPS> tprojarray[8] = {tproj1,tproj2,tproj3,tproj4,tproj5,tproj6,tproj7,tproj8};
+    VMProjectionMemory<BARREL> vmprojarray[8] = {vmproj1,vmproj2,vmproj3,vmproj4,vmproj5,vmproj6,vmproj7,vmproj8};
     
     // bx
     BXType bx = ievt;
     BXType bx_out;
 
     // Unit Under Test
-    ProjectionRouterTop(bx,
-                        tprojarray,
-                        bx_out,
-                        &allproj,
-                        &vmproj1, &vmproj2, &vmproj3, &vmproj4,
-                        &vmproj5, &vmproj6, &vmproj7, &vmproj8);
+    ProjectionRouterTop(bx, tprojarray, bx_out, allproj, vmprojarray);
 
     // compare the computed outputs with the expected ones
     bool truncation = false;
@@ -149,35 +145,35 @@ int main()
       (allproj,fout_aproj, ievt, "AllProjection", truncation, kMaxProc-10);
     // VMProjection1
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj1, fout_vmproj1, ievt, "VMProjection1", truncation, kMaxProc-10);
+      (vmprojarray[0], fout_vmproj1, ievt, "VMProjection1", truncation, kMaxProc-10);
 
     // VMProjection2
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj2, fout_vmproj2, ievt, "VMProjection2", truncation, kMaxProc-10);
+      (vmprojarray[1], fout_vmproj2, ievt, "VMProjection2", truncation, kMaxProc-10);
 
     // VMProjection3
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj3, fout_vmproj3, ievt, "VMProjection3", truncation, kMaxProc-10);
+      (vmprojarray[2], fout_vmproj3, ievt, "VMProjection3", truncation, kMaxProc-10);
 
     // VMProjection4
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj4, fout_vmproj4, ievt, "VMProjection4", truncation, kMaxProc-10);
+      (vmprojarray[3], fout_vmproj4, ievt, "VMProjection4", truncation, kMaxProc-10);
 
     // VMProjection5
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj5, fout_vmproj5, ievt, "VMProjection5", truncation, kMaxProc-10);
+      (vmprojarray[4], fout_vmproj5, ievt, "VMProjection5", truncation, kMaxProc-10);
 
     // VMProjection6
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj6, fout_vmproj6, ievt, "VMProjection6", truncation, kMaxProc-10);
+      (vmprojarray[5], fout_vmproj6, ievt, "VMProjection6", truncation, kMaxProc-10);
 
     // VMProjection7
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj7, fout_vmproj7, ievt, "VMProjection7", truncation, kMaxProc-10);
+      (vmprojarray[6], fout_vmproj7, ievt, "VMProjection7", truncation, kMaxProc-10);
 
     // VMProjection8
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmproj8, fout_vmproj8, ievt, "VMProjection8", truncation, kMaxProc-10);
+      (vmprojarray[7], fout_vmproj8, ievt, "VMProjection8", truncation, kMaxProc-10);
     
   } // end of event loop
   

--- a/TestBenches/ProjectionRouter_test.cpp
+++ b/TestBenches/ProjectionRouter_test.cpp
@@ -127,6 +127,8 @@ int main()
     writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj6, fin_tproj6, ievt);
     writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj7, fin_tproj7, ievt);
     writeMemFromFile<TrackletProjectionMemory<BARRELPS> >(tproj8, fin_tproj8, ievt);
+
+    TrackletProjectionMemory<BARRELPS> tprojarray[8] = {tproj1,tproj2,tproj3,tproj4,tproj5,tproj6,tproj7,tproj8};
     
     // bx
     BXType bx = ievt;
@@ -134,8 +136,7 @@ int main()
 
     // Unit Under Test
     ProjectionRouterTop(bx,
-                        &tproj1, &tproj2, &tproj3, &tproj4,
-                        &tproj5, &tproj6, &tproj7, &tproj8,
+                        tprojarray,
                         bx_out,
                         &allproj,
                         &vmproj1, &vmproj2, &vmproj3, &vmproj4,

--- a/TrackletAlgorithm/ProjectionRouter.h
+++ b/TrackletAlgorithm/ProjectionRouter.h
@@ -11,109 +11,30 @@
 
 namespace PR
 {
-
-  //////////////////////////////
-  // Initialization
-  // check the number of entries in the input memories
-  // fill the bit mask indicating if memories are empty or not
-  template<int nMEM, int NBits_Entries, class MemType>
-  inline void init(BXType bx,
-                   // bitmasks to indicate if memories are empty
-                   ap_uint<nMEM>& mem_hasdata,
-                   // number of entries for each memory
-                   ap_uint<NBits_Entries> nentries[nMEM],
-                   const int i,
-                   const MemType* const mem)
-  {    
-#pragma HLS inline  
-    ap_uint<kNBits_MemAddr+1> num = mem->getEntries(bx);
-    nentries[i] = num;
-    if (num > 0) mem_hasdata.set(i);
-  }
-  
-  // recursive case
-  template<int nMEM, int NBits_Entries, class MemType, class... Args>
-  inline void init(BXType bx, ap_uint<nMEM>& mem_hasdata,
-                   ap_uint<NBits_Entries> nentries[nMEM],
-                   const int i,
-                   const MemType* const mem, Args... args)
-  {
-#pragma HLS inline 
-    ap_uint<kNBits_MemAddr+1> num = mem->getEntries(bx);
-    nentries[i] = num;
-    if (num > 0) mem_hasdata.set(i);
-
-    if (i+1 < nMEM) init(bx, mem_hasdata, nentries, i+1, args...);
-  }
-
-  //////////////////////////////
-  // Priority encoder based input memory reading logic
-  template<class DataType, class MemType>
-  void read_inmem(DataType& data, BXType bx, ap_uint<5> read_imem,
-                  ap_uint<kNBits_MemAddr>& read_addr,
-                  const int i, const MemType* const inmem)
-  {
-#pragma HLS inline
-    if (read_imem == i) data = inmem->read_mem(bx, read_addr);
-  }
-
-  template<class DataType, class MemType, class... Args>
-  void read_inmem(DataType& data, BXType bx, ap_uint<5> read_imem,
-                  ap_uint<kNBits_MemAddr>& read_addr,
-                  const int i,
-                  const MemType* const inmem, Args... args)
-  {
-    if (read_imem == i) data = inmem->read_mem(bx, read_addr);
-    read_inmem(data, bx, read_imem, read_addr, i+1, args...);
-  }
-
-  
-  template<class DataType, class MemType, int nMEM, int NBits_Entries>
-  bool read_input_mems(BXType bx,
-                       ap_uint<nMEM>& mem_hasdata,
-                       ap_uint<NBits_Entries> nentries[nMEM],
+  template<regionType PROJTYPE, unsigned int nINMEM>
+  bool new_read_input_mems(BXType bx,
+                       ap_uint<nINMEM>& mem_hasdata,
+                       ap_uint<kNBits_MemAddr> nentries[nINMEM],
                        ap_uint<kNBits_MemAddr>& read_addr,
-                       // memory pointers
-                       const MemType* const mem0, const MemType* const mem1,
-                       const MemType* const mem2, const MemType* const mem3,
-                       const MemType* const mem4, const MemType* const mem5,
-                       const MemType* const mem6, const MemType* const mem7,
-                       const MemType* const mem8, const MemType* const mem9,
-                       const MemType* const mem10, const MemType* const mem11,
-                       const MemType* const mem12, const MemType* const mem13,
-                       const MemType* const mem14, const MemType* const mem15,
-                       const MemType* const mem16, const MemType* const mem17,
-                       const MemType* const mem18, const MemType* const mem19,
-                       const MemType* const mem20, const MemType* const mem21,
-                       const MemType* const mem22, const MemType* const mem23,
-                       DataType& data)
+                       const TrackletProjectionMemory<PROJTYPE> projin[],
+                       TrackletProjection<PROJTYPE>& data) 
   {
 #pragma HLS inline
+
     if (mem_hasdata == 0) return false;
-
-    // 5 bits memory index for up to 32 input memories
-    // priority encoder
-    ap_uint<5> read_imem = __builtin_ctz(mem_hasdata);
-
-    // read the memory "read_imem" with the address "read_addr"
-    read_inmem(data, bx, read_imem, read_addr, 0,
-               mem0,mem1,mem2,mem3,mem4,mem5,mem6,mem7,
-               mem8,mem9,mem10,mem11,mem12,mem13,mem14,mem15,
-               mem16,mem17,mem18,mem19,mem20,mem21,mem22,mem23);
-
-    // Increase the read address
+    // 3 bits memory index for up to 8 input memory priority encoder
+    ap_uint<3> read_imem = __builtin_ctz(mem_hasdata);
+    data = projin[read_imem].read_mem(bx, read_addr);
     ++read_addr;
-
     if (read_addr >= nentries[read_imem]) {
-      // All entries in the memory[read_imem] have been read out
-      // Prepare to move to the next non-empty memory
+      // All entries in the memory[read_imem] have been read out - Prepare to move to the next non-empty memory
       read_addr = 0;
       mem_hasdata.clear(read_imem);  // set the current lowest 1 bit to 0
     }
 
     return true;
-    
-  } // read_input_mems
+
+  } // new_read_input_mems
 
   /////////////////////////////////////////////////////
   // FIXME
@@ -143,33 +64,7 @@ namespace PR
 template<regionType PROJTYPE, regionType VMPTYPE, unsigned int nINMEM,
          int LAYER=0, int DISK=0>
 void ProjectionRouter(BXType bx,
-                      // because Vivado HLS cannot synthesize an array of
-                      // pointers that point to stuff other than scalar or
-                      // array of scalar ...
-                      const TrackletProjectionMemory<PROJTYPE>* const proj1in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj2in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj3in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj4in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj5in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj6in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj7in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj8in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj9in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj10in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj11in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj12in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj13in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj14in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj15in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj16in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj17in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj18in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj19in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj20in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj21in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj22in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj23in,
-                      const TrackletProjectionMemory<PROJTYPE>* const proj24in,
+                      const TrackletProjectionMemory<PROJTYPE> projin[],
                       BXType& bx_o,
                       AllProjectionMemory<PROJTYPE>* const allprojout,
                       VMProjectionMemory<VMPTYPE>* const vmprojout1,
@@ -182,6 +77,7 @@ void ProjectionRouter(BXType bx,
                       VMProjectionMemory<VMPTYPE>* const vmprojout8
 ){
 #pragma HLS inline
+#pragma HLS array_partition variable=projin complete dim=1
 
   using namespace PR;
   
@@ -200,16 +96,14 @@ void ProjectionRouter(BXType bx,
   // check the number of entries in the input memories
   // fill the bit mask indicating if memories are empty or not
   ap_uint<nINMEM> mem_hasdata = 0;
-  ap_uint<kNBits_MemAddr+1> numbersin[nINMEM];
+  ap_uint<kNBits_MemAddr> numbersin[nINMEM];
 #pragma HLS ARRAY_PARTITION variable=numbersin complete dim=0
+  for (int i=0; i<nINMEM; i++) {
+#pragma HLS unroll
+    numbersin[i] = projin[i].getEntries(bx);
+    if (numbersin[i] > 0) mem_hasdata.set(i);
+  }
 
-  //init<nINMEM, kNBits_MemAddr+1, TrackletProjectionMemory<PROJTYPE>>
-  init<nINMEM, kNBits_MemAddr+1, TrackletProjectionMemory<PROJTYPE>>
-    (bx, mem_hasdata, numbersin,0,
-     proj1in,proj2in,proj3in,proj4in,proj5in,proj6in,proj7in,proj8in,
-     proj9in,proj10in,proj11in,proj12in,proj13in,proj14in,proj15in,proj16in,
-     proj17in,proj18in,proj19in,proj20in,proj21in,proj22in,proj23in,proj24in);
-  
   // declare index of input memory to be read
   ap_uint<kNBits_MemAddr> mem_read_addr = 0;
 
@@ -229,14 +123,7 @@ void ProjectionRouter(BXType bx,
 
     // read inputs
     TrackletProjection<PROJTYPE> tproj;
-    bool validin = read_input_mems<TrackletProjection<PROJTYPE>,
-                                   TrackletProjectionMemory<PROJTYPE>,
-                                   nINMEM, kNBits_MemAddr+1>
-      (bx, mem_hasdata, numbersin, mem_read_addr,
-       proj1in, proj2in, proj3in, proj4in, proj5in, proj6in, proj7in, proj8in,
-       proj9in, proj10in, proj11in, proj12in, proj13in, proj14in, proj15in, proj16in,
-       proj17in, proj18in, proj19in, proj20in, proj21in, proj22in, proj23in, proj24in,
-       tproj);
+    bool validin = new_read_input_mems<PROJTYPE,nINMEM>(bx, mem_hasdata, numbersin, mem_read_addr, projin, tproj);
 
     if (validin) {
     

--- a/TrackletAlgorithm/ProjectionRouterTop.cc
+++ b/TrackletAlgorithm/ProjectionRouterTop.cc
@@ -3,16 +3,8 @@
 void ProjectionRouterTop(BXType bx,
                          const TrackletProjectionMemory<BARRELPS> projin[8],
                          BXType& bx_o,
-                         AllProjectionMemory<BARRELPS>* allprojout,
-                         VMProjectionMemory<BARREL>* vmprojout1,
-                         VMProjectionMemory<BARREL>* vmprojout2,
-                         VMProjectionMemory<BARREL>* vmprojout3,
-                         VMProjectionMemory<BARREL>* vmprojout4,
-                         VMProjectionMemory<BARREL>* vmprojout5,
-                         VMProjectionMemory<BARREL>* vmprojout6,
-                         VMProjectionMemory<BARREL>* vmprojout7,
-                         VMProjectionMemory<BARREL>* vmprojout8
-                         )
+                         AllProjectionMemory<BARRELPS>& allprojout,
+                         VMProjectionMemory<BARREL> vmprojout[8])
 {
  #pragma HLS inline off
  #pragma HLS interface register port=bx_o
@@ -25,8 +17,6 @@ void ProjectionRouterTop(BXType bx,
  #pragma HLS resource variable=projin[6]->get_mem() latency=2
  #pragma HLS resource variable=projin[7]->get_mem() latency=2
   // PR_L3PHIC
- PR_L3PHIC: ProjectionRouter<BARRELPS, BARREL, 8, 3, 0>
-    (bx,
-     projin, bx_o, allprojout, vmprojout1, vmprojout2, vmprojout3, vmprojout4, vmprojout5, vmprojout6, vmprojout7, vmprojout8
-     );
+ PR_L3PHIC: ProjectionRouter<BARRELPS, BARREL, 8, 8, 3, 0>
+    (bx, projin, bx_o, allprojout, vmprojout);
 }

--- a/TrackletAlgorithm/ProjectionRouterTop.cc
+++ b/TrackletAlgorithm/ProjectionRouterTop.cc
@@ -1,14 +1,7 @@
 #include "ProjectionRouterTop.h"
 
 void ProjectionRouterTop(BXType bx,
-                         const TrackletProjectionMemory<BARRELPS>* proj1in,
-                         const TrackletProjectionMemory<BARRELPS>* proj2in,
-                         const TrackletProjectionMemory<BARRELPS>* proj3in,
-                         const TrackletProjectionMemory<BARRELPS>* proj4in,
-                         const TrackletProjectionMemory<BARRELPS>* proj5in,
-                         const TrackletProjectionMemory<BARRELPS>* proj6in,
-                         const TrackletProjectionMemory<BARRELPS>* proj7in,
-                         const TrackletProjectionMemory<BARRELPS>* proj8in,
+                         const TrackletProjectionMemory<BARRELPS> projin[8],
                          BXType& bx_o,
                          AllProjectionMemory<BARRELPS>* allprojout,
                          VMProjectionMemory<BARREL>* vmprojout1,
@@ -23,22 +16,17 @@ void ProjectionRouterTop(BXType bx,
 {
  #pragma HLS inline off
  #pragma HLS interface register port=bx_o
- #pragma HLS resource variable=proj1in->get_mem() latency=2
- #pragma HLS resource variable=proj2in->get_mem() latency=2
- #pragma HLS resource variable=proj3in->get_mem() latency=2
- #pragma HLS resource variable=proj4in->get_mem() latency=2
- #pragma HLS resource variable=proj5in->get_mem() latency=2
- #pragma HLS resource variable=proj6in->get_mem() latency=2
- #pragma HLS resource variable=proj7in->get_mem() latency=2
- #pragma HLS resource variable=proj8in->get_mem() latency=2
+ #pragma HLS resource variable=projin[0]->get_mem() latency=2
+ #pragma HLS resource variable=projin[1]->get_mem() latency=2
+ #pragma HLS resource variable=projin[2]->get_mem() latency=2
+ #pragma HLS resource variable=projin[3]->get_mem() latency=2
+ #pragma HLS resource variable=projin[4]->get_mem() latency=2
+ #pragma HLS resource variable=projin[5]->get_mem() latency=2
+ #pragma HLS resource variable=projin[6]->get_mem() latency=2
+ #pragma HLS resource variable=projin[7]->get_mem() latency=2
   // PR_L3PHIC
  PR_L3PHIC: ProjectionRouter<BARRELPS, BARREL, 8, 3, 0>
     (bx,
-     proj1in, proj2in, proj3in, proj4in, proj5in, proj6in, proj7in, proj8in,
-     nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-     nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-     bx_o,
-     allprojout,
-     vmprojout1, vmprojout2, vmprojout3, vmprojout4, vmprojout5, vmprojout6, vmprojout7, vmprojout8
+     projin, bx_o, allprojout, vmprojout1, vmprojout2, vmprojout3, vmprojout4, vmprojout5, vmprojout6, vmprojout7, vmprojout8
      );
 }

--- a/TrackletAlgorithm/ProjectionRouterTop.h
+++ b/TrackletAlgorithm/ProjectionRouterTop.h
@@ -4,17 +4,9 @@
 #include "ProjectionRouter.h"
 
 void ProjectionRouterTop(BXType bx,
-                         const TrackletProjectionMemory<BARRELPS> projin[8],
+                         const TrackletProjectionMemory<BARRELPS>*,
                          BXType&,
-                         AllProjectionMemory<BARRELPS>*,
-                         VMProjectionMemory<BARREL>*,
-                         VMProjectionMemory<BARREL>*,
-                         VMProjectionMemory<BARREL>*,
-                         VMProjectionMemory<BARREL>*,
-                         VMProjectionMemory<BARREL>*,
-                         VMProjectionMemory<BARREL>*,
-                         VMProjectionMemory<BARREL>*,
-                         VMProjectionMemory<BARREL>*
-                         );
+                         AllProjectionMemory<BARRELPS>&,
+                         VMProjectionMemory<BARREL>*);
 
 #endif

--- a/TrackletAlgorithm/ProjectionRouterTop.h
+++ b/TrackletAlgorithm/ProjectionRouterTop.h
@@ -4,14 +4,7 @@
 #include "ProjectionRouter.h"
 
 void ProjectionRouterTop(BXType bx,
-                         const TrackletProjectionMemory<BARRELPS>*,
-                         const TrackletProjectionMemory<BARRELPS>*,
-                         const TrackletProjectionMemory<BARRELPS>*,
-                         const TrackletProjectionMemory<BARRELPS>*,
-                         const TrackletProjectionMemory<BARRELPS>*,
-                         const TrackletProjectionMemory<BARRELPS>*,
-                         const TrackletProjectionMemory<BARRELPS>*,
-                         const TrackletProjectionMemory<BARRELPS>*,
+                         const TrackletProjectionMemory<BARRELPS> projin[8],
                          BXType&,
                          AllProjectionMemory<BARRELPS>*,
                          VMProjectionMemory<BARREL>*,


### PR DESCRIPTION
Change to using arrays of memory classes for inputs and outputs of Projection Router rather than individual pointers. In addition to simplifying the code on the interface (the synthesized interface is unchanged except port names), the logic for reading the input memories has been fairly substantially simplified which resulted in the new PR using about 60% of the resources of the old PR (FF and LUTs, mainly).