### PR TITLE
Download separate MemPrints and LUTs tarballs

### DIFF
--- a/emData/download.sh
+++ b/emData/download.sh
@@ -66,11 +66,19 @@ do
   shift
 done
 
-# If either the MemPrints or the LUTs directory exists, assume the script has
-# already been run, and simply exit.
-if [ -d "MemPrints" ] || [ -d "LUTs" ]
+# If the MemPrints directory exists, assume the script has already been run,
+# and simply exit.
+if [ -d "MemPrints" ]
 then
   exit 0
+fi
+
+# If the LUTs directory exists, assume LUTs.tar.gz has already been downloaded
+# and unpacked, and only download and unpack MemPrints.tar.gz.
+memprints_only=0
+if [ -d "LUTs" ]
+then
+  memprints_only=1
 fi
 
 # Exit with an error message if run from a directory other than emData/.
@@ -82,9 +90,12 @@ then
 fi
 
 # Download and unpack LUTs.tar.gz.
-wget -O LUTs.tar.gz --quiet ${luts_url}
-tar -xzf LUTs.tar.gz
-rm -f LUTs.tar.gz
+if [[ $memprints_only == 0 ]]
+then
+  wget -O LUTs.tar.gz --quiet ${luts_url}
+  tar -xzf LUTs.tar.gz
+  rm -f LUTs.tar.gz
+fi
 
 # Exit now if we are only downloading and unpacking LUTs.tar.gz.
 if [[ $tables_only != 0 ]]

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -37,6 +37,31 @@ declare -a processing_modules=(
   "MC_L6PHIC"
 )
 
+# Function that prints information regarding the usage of this command
+function usage() {
+  echo "$(basename $0) [-h|--help] [-t|--tables]"
+  echo ""
+  echo "Options:"
+  echo "  -h, --help    show this help message and exit"
+  echo "  -t, --tables  download and unpack only LUTs.tar.gz"
+}
+
+# Parse the command line options.
+tables_only=0
+while [[ $1 != "" ]]
+do
+  case $1 in
+    -t | --tables )  tables_only=1
+                     ;;
+    -h | --help )    usage
+                     exit
+                     ;;
+    * )              usage
+                     exit 1
+  esac
+  shift
+done
+
 # If either the MemPrints or the LUTs directory exists, assume the script has
 # already been run, and simply exit.
 if [ -d "MemPrints" ] || [ -d "LUTs" ]
@@ -56,6 +81,12 @@ fi
 wget -O LUTs.tar.gz --quiet ${luts_url}
 tar -xzf LUTs.tar.gz
 rm -f LUTs.tar.gz
+
+# Exit now if we are only downloading and unpacking LUTs.tar.gz.
+if [[ $tables_only != 0 ]]
+then
+  exit 0
+fi
 
 # Download and unpack MemPrints.tar.gz.
 wget -O MemPrints.tar.gz --quiet ${memprints_url}

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # fw_synch_200515
-tarball_url="https://cernbox.cern.ch/index.php/s/tsxTkilHDVhnbYF/download"
+memprints_url="https://cernbox.cern.ch/index.php/s/QvV86Qcc8n9R4sg/download"
+luts_url="https://cernbox.cern.ch/index.php/s/YSER9ne7WVxiKXI/download"
 
 # The following modules will have dedicated directories of test-bench files
 # prepared for them.
@@ -36,9 +37,9 @@ declare -a processing_modules=(
   "MC_L6PHIC"
 )
 
-# If the MemPrints directory exists, assume the script has already been run,
-# and simply exit.
-if [ -d "MemPrints" ]
+# If either the MemPrints or the LUTs directory exists, assume the script has
+# already been run, and simply exit.
+if [ -d "MemPrints" ] || [ -d "LUTs" ]
 then
   exit 0
 fi
@@ -51,8 +52,13 @@ then
   exit 1
 fi
 
-# Download and unpack the tarball.
-wget -O MemPrints.tar.gz --quiet ${tarball_url}
+# Download and unpack LUTs.tar.gz.
+wget -O LUTs.tar.gz --quiet ${luts_url}
+tar -xzf LUTs.tar.gz
+rm -f LUTs.tar.gz
+
+# Download and unpack MemPrints.tar.gz.
+wget -O MemPrints.tar.gz --quiet ${memprints_url}
 tar -xzf MemPrints.tar.gz
 rm -f MemPrints.tar.gz
 
@@ -75,7 +81,7 @@ do
   done
 
   # Table linking logic specific to each module type
-  table_location="MemPrints/Tables/"
+  table_location="LUTs/"
   table_target_dir="${module_type}/tables"
   if [[ ! -d "${table_target_dir}" ]]
   then

--- a/emData/download.sh
+++ b/emData/download.sh
@@ -41,6 +41,10 @@ declare -a processing_modules=(
 function usage() {
   echo "$(basename $0) [-h|--help] [-t|--tables]"
   echo ""
+  echo "Without any options, downloads and unpacks MemPrints.tar.gz and LUTs.tar.gz."
+  echo "MemPrints.tar.gz contains test vectors produced by the emulation, and"
+  echo "LUTs.tar.gz contains lookup tables and other small miscellaneous files."
+  echo ""
   echo "Options:"
   echo "  -h, --help    show this help message and exit"
   echo "  -t, --tables  download and unpack only LUTs.tar.gz"


### PR DESCRIPTION
This PR splits the single tarball into two:
- MemPrints.tar.gz contains the test vectors that are the inputs and outputs used by the HLS test benches
- LUTs.tar.gz contains lookup tables, as well as other small files copied from L1Trigger/TrackFindingTracklet/data/, that may potentially be used in an HLS module

For the sake of the eventual HLS-based emulation, `download.sh` now also accepts an option for downloading and unpacking only LUTs.tar.gz, while preserving the default behavior of downloading and unpacking everything when no option is given:
```
download.sh [-h|--help] [-t|--tables]

Options:
  -h, --help    show this help message and exit
  -t, --tables  download and unpack only LUTs.tar.gz
```

This should address #108. These changes have already been made on the fw_synch branch, but since the synchronization is taking some time to complete, I wanted to go ahead and add them to the master branch now.