### PR TITLE
Remove NEntries ports from output memories for each module

### DIFF
--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -30,33 +30,6 @@ bool openDataFile(std::ifstream& file_in, const std::string& file_name)
   return success;
 }
 
-template<class DataType>
-void readEventFromFile(DataType& memarray, std::ifstream& fin, int ievt){
-
-  std::string line;
-
-  if (ievt==0) {
-    getline(fin, line);
-  }
-
-  memarray.clear(ievt);
-
-  while (getline(fin, line)) {
-    
-    if (!fin.good()) {
-      return;
-    }
-
-    if (line.find("Event") != std::string::npos) {
-	return;
-    }
-    else {
-      memarray.write_mem_line(ievt,line);
-    }
-    
-  }
-}
-
 std::vector<std::string> split(const std::string& s, char delimiter)
 {
   std::vector<std::string> tokens;
@@ -95,28 +68,17 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
        memory.write_mem(ievt, line, base);
       } else {
 	const std::string datastr = split(line, ' ').back();
-	memory.write_mem(ievt, datastr, base);
+        memory.write_mem(ievt, datastr, base);
       }
     }	
   }
   
 }
 
-// TODO: FIXME or write a new one for binned memories
-template<class MemType, int InputBase=16, int OutputBase=16>
-unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
-                                int ievt, const std::string& label)
-{
-  bool truncated = false;
-  unsigned int err_count;
-  err_count = compareMemWithFile<MemType,InputBase,OutputBase>(memory,fout,ievt,label,truncated);
-  return err_count;
-}
-
 template<class MemType, int InputBase=16, int OutputBase=16>
 unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
                                 int ievt, const std::string& label,
-                                bool& truncated, int maxProc = kMaxProc)
+                                bool truncated = false, int maxProc = kMaxProc)
 {
   unsigned int err_count = 0;
 
@@ -125,62 +87,41 @@ unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
   MemType memory_ref;
   writeMemFromFile<MemType>(memory_ref, fout, ievt, InputBase);
 
-  // Check if at least one of the memories in comparison is non empty
-  // before spamming the screen
-  if (memory_ref.getEntries(ievt) or memory.getEntries(ievt)) {
-    std::cout << label << ":" << std::endl;
-  }
-
-  ////////////////////////////////////////
-  // compare expected data with those computed and stored in the output memory
-  if (memory.getEntries(ievt)!=0 or memory_ref.getEntries(ievt)!=0)
-    std::cout << "index" << "\t" << "reference" << "\t" << "computed" << std::endl;
-  
-  for (int i = 0; i < memory_ref.getEntries(ievt); ++i) {
-
-    // Maximum processing steps per event is kMaxProc
-    if (i >= maxProc) {
-      std::cout << "WARNING: Extra data in the reference memory!" << std::endl;
-      std::cout << "Truncation due to maximum number of processing steps per event maxProc = " << std::dec << maxProc << std::endl;
-      truncated = true;
-      break;
-    }
-    
-    std::cout << i << "\t";
-
+  for (int i = 0; i < memory_ref.getDepth(); ++i) {
     auto data_ref = memory_ref.read_mem(ievt,i).raw();
+    auto data_com = memory.read_mem(ievt,i).raw();
+    if (i==0) {
+      // If both reference and computed memories are completely empty, skip it
+      if (data_com == 0 && data_ref == 0) break;
+      std::cout << label << ":" << std::endl;
+      std::cout << "index" << "\t" << "reference" << "\t" << "computed" << std::endl;
+    }
+    // If have reached the end of valid entries in both computed and reference, don't bother printing further
+    if (data_com == 0 && data_ref == 0) continue;
+
+    std::cout << i << "\t";
     if (OutputBase == 2) std::cout << std::bitset<MemType::getWidth()>(data_ref) << "\t";
     else                 std::cout << std::hex << data_ref << "\t";
     
-    if (i >= memory.getEntries(ievt) ) {
-      // missing entries in the computed memory
-      if (not truncated) err_count++;
-      std::cout << "missing" << std::endl;
-      continue;
-    }
-
-    auto data_com = memory.read_mem(ievt,i).raw();
     if (OutputBase == 2) std::cout << std::bitset<MemType::getWidth()>(data_com);
     else                 std::cout << std::hex << data_com; // << std::endl;
 
-    if (data_com != data_ref) {
+    // If there is extra entries in reference
+    if (data_com == 0) {
+      std::cout << "\t" << "<=== missing";
+      if (!truncated) err_count++;
+    // If there is extra entries in computed
+    } else if (data_ref == 0) {
+      std::cout << "\t" << "<=== EXTRA";
+      err_count++;
+    // If reference and computed entry are inconsistent
+    } else if (data_com != data_ref) {
       std::cout << "\t" << "<=== INCONSISTENT";
       err_count++;
     }
-
     std::cout << std::endl;
   }
   
-  // in case computed memory has extra contents...
-  if (memory.getEntries(ievt) >  memory_ref.getEntries(ievt)) {
-    
-    for (int i = memory_ref.getEntries(ievt); i < memory.getEntries(ievt); ++i) {
-      auto data_extra = memory.read_mem(ievt, i).raw();   
-      std::cout << "missing" << "\t" << std::hex << data_extra << std::endl;
-      err_count++;
-    }
-  }
-
   return err_count;
   
 }
@@ -189,7 +130,7 @@ template<class MemType, int InputBase=16, int OutputBase=16>
 unsigned int compareBinnedMemWithFile(const MemType& memory, 
                                       std::ifstream& fout,
                                       int ievt, const std::string& label,
-                                      bool& truncated, int maxProc = kMaxProc)
+                                      bool& truncated = false, int maxProc = kMaxProc)
 {
   unsigned int err_count = 0;
 
@@ -198,67 +139,43 @@ unsigned int compareBinnedMemWithFile(const MemType& memory,
   MemType memory_ref;
   writeMemFromFile<MemType>(memory_ref, fout, ievt, InputBase);
 
-  // Check if at least one of the memories in comparison is non empty
-  // before spamming the screen
-  if (memory_ref.getEntries(ievt) or memory.getEntries(ievt)) {
-    std::cout << label << ":" << std::endl;
-  }
-  else 
-    return err_count;
-
   ////////////////////////////////////////
   // compare expected data with those computed and stored in the output memory
+  std::cout << label << ":" << std::endl;
   std::cout << "index" << "\t" << "reference" << "\t" << "computed" << std::endl;
   for ( int j = 0; j < memory_ref.getNBins(); ++j ) {
-    auto val = memory_ref.getEntries(ievt,j);
-    std::cout << "Bin " << std::dec << j
-	      << ", n_entries = " << val 
-	      << std::endl;
-    for (int i = 0; i < val ; ++i) {
+    std::cout << "Bin " << std::dec << j << std::endl;
+    for (int i = 0; i < memory_ref.getNEntryPerBin() ; ++i) {
+      auto data_ref = memory_ref.read_mem(ievt,j,i).raw();
+      auto data_com = memory.read_mem(ievt,j,i).raw();
 
-      // Maximum processing steps per event is kMaxProc
-      if (i >= maxProc) {
-	std::cout << "WARNING: Extra data in the reference memory!" << std::endl;
-	std::cout << "Truncation due to maximum number of processing steps per event maxProc = " << std::dec << maxProc << std::endl;
-	truncated = true;
-	break;
-      }
-      
+      // If have reached the end of valid entries in both computed and reference, don't bother printing further
+      if (data_com == 0 && data_ref == 0) continue;
+
       std::cout << i << "\t";
 
-      auto data_ref = memory_ref.read_mem(ievt,j,i).raw();
       if (OutputBase == 2) std::cout << std::bitset<MemType::getWidth()>(data_ref) << "\t";
       else                 std::cout << std::hex << data_ref << "\t";
     
-      if (i >= memory.getEntries(ievt,j) ) {
-	// missing entries in the computed memory
-	if (not truncated) err_count++;
-	std::cout << "missing" << std::endl;
-	continue;
-      }
-
-      auto data_com = memory.read_mem(ievt,j,i).raw();
       if (OutputBase ==2) std::cout << std::bitset<MemType::getWidth()>(data_com);
       else                std::cout << std::hex << data_com; // << std::endl;
 
-      if (data_com != data_ref) {
-	std::cout << "\t" << "<=== INCONSISTENT";
-	err_count++;
+      // If there is extra entries in reference
+      if (data_com == 0) {
+        std::cout << "\t" << "<=== missing";
+        if (!truncated) err_count++;
+      // If there is extra entries in computed
+      } else if (data_ref == 0) {
+        std::cout << "\t" << "<=== EXTRA";
+        err_count++;
+      // If reference and computed entry are inconsistent
+      } else if (data_com != data_ref) {
+        std::cout << "\t" << "<=== INCONSISTENT";
+        err_count++;
       }
-
       std::cout << std::endl;
-    } // loop over single bin
-    // in case computed memory has extra contents...
-    if (memory.getEntries(ievt) >  memory_ref.getEntries(ievt)) {
-    
-      for (int i = memory_ref.getEntries(ievt,j); i < memory.getEntries(ievt,j); ++i) {
-	auto data_extra = memory.read_mem(ievt,j, i).raw();   
-	std::cout << "missing" << "\t" << std::hex << data_extra << std::endl;
-	err_count++;
-      }
-    }
+    } // loop over entries in bin
   } // loop over bins
-
 
   return err_count;
   

--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -68,7 +68,7 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
        memory.write_mem(ievt, line, base);
       } else {
 	const std::string datastr = split(line, ' ').back();
-        memory.write_mem(ievt, datastr, base);
+	memory.write_mem(ievt, datastr, base);
       }
     }	
   }
@@ -78,7 +78,7 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
 template<class MemType, int InputBase=16, int OutputBase=16>
 unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
                                 int ievt, const std::string& label,
-                                bool truncated = false, int maxProc = kMaxProc)
+                                bool& truncated = false, int maxProc = kMaxProc)
 {
   unsigned int err_count = 0;
 
@@ -119,6 +119,7 @@ unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
       std::cout << "\t" << "<=== INCONSISTENT";
       err_count++;
     }
+
     std::cout << std::endl;
   }
   
@@ -173,6 +174,7 @@ unsigned int compareBinnedMemWithFile(const MemType& memory,
         std::cout << "\t" << "<=== INCONSISTENT";
         err_count++;
       }
+
       std::cout << std::endl;
     } // loop over entries in bin
   } // loop over bins

--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -78,7 +78,7 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
 template<class MemType, int InputBase=16, int OutputBase=16>
 unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
                                 int ievt, const std::string& label,
-                                const bool& truncated = false, int maxProc = kMaxProc)
+                                const bool truncated = false, int maxProc = kMaxProc)
 {
   unsigned int err_count = 0;
 
@@ -131,7 +131,7 @@ template<class MemType, int InputBase=16, int OutputBase=16>
 unsigned int compareBinnedMemWithFile(const MemType& memory, 
                                       std::ifstream& fout,
                                       int ievt, const std::string& label,
-                                      const bool& truncated = false, int maxProc = kMaxProc)
+                                      const bool truncated = false, int maxProc = kMaxProc)
 {
   unsigned int err_count = 0;
 

--- a/TestBenches/FileReadUtility.h
+++ b/TestBenches/FileReadUtility.h
@@ -78,7 +78,7 @@ void writeMemFromFile(MemType& memory, std::ifstream& fin, int ievt, int base=16
 template<class MemType, int InputBase=16, int OutputBase=16>
 unsigned int compareMemWithFile(const MemType& memory, std::ifstream& fout,
                                 int ievt, const std::string& label,
-                                bool& truncated = false, int maxProc = kMaxProc)
+                                const bool& truncated = false, int maxProc = kMaxProc)
 {
   unsigned int err_count = 0;
 
@@ -131,7 +131,7 @@ template<class MemType, int InputBase=16, int OutputBase=16>
 unsigned int compareBinnedMemWithFile(const MemType& memory, 
                                       std::ifstream& fout,
                                       int ievt, const std::string& label,
-                                      bool& truncated = false, int maxProc = kMaxProc)
+                                      const bool& truncated = false, int maxProc = kMaxProc)
 {
   unsigned int err_count = 0;
 

--- a/TestBenches/MatchCalculator_test.cpp
+++ b/TestBenches/MatchCalculator_test.cpp
@@ -77,6 +77,15 @@ int main() {
   for (int ievt = 0; ievt < nevents; ++ievt) {
     //cout << "Event: " << dec << ievt << endl;
 
+    fullmatch[0].clear();
+//    fullmatch[1].clear();
+//    fullmatch[2].clear();
+    fullmatch[3].clear();
+//    fullmatch[4].clear();
+//    fullmatch[5].clear();
+//    fullmatch[6].clear();
+//    fullmatch[7].clear();
+
     // make memories from the input text files
     writeMemFromFile<AllStubMemory<BARRELPS> >(allstub, fin_as, ievt);
     writeMemFromFile<AllProjectionMemory<BARRELPS> >(allproj, fin_ap, ievt);
@@ -138,5 +147,7 @@ int main() {
   fout_fm7.close();
   fout_fm7.close();
 
+  // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+  if (err_count > 255) err_count = 255;
   return err_count;
 }

--- a/TestBenches/MatchEngine_test.cpp
+++ b/TestBenches/MatchEngine_test.cpp
@@ -73,6 +73,8 @@ int main() {
 	for (int ievt = 0; ievt < nevents; ++ievt) {
 		cout << "Event: " << dec << ievt << endl;
 
+                outputcandmatches.clear();
+
 		writeMemFromFile<VMProjectionMemory<PROJECTIONTYPE> >(inputvmprojs, fin_vmproj, ievt);
 		writeMemFromFile<VMStubMEMemory<MODULETYPE, NBITBIN> >(inputvmstubs, fin_vmstub, ievt);
 
@@ -100,6 +102,7 @@ int main() {
 	fin_vmstub.close();
 	fin_vmproj.close();
 	fin_candmatch.close();
-
+        // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+        if (err_count > 255) err_count = 255;
 	return err_count;
 }

--- a/TestBenches/MatchEngine_test.cpp
+++ b/TestBenches/MatchEngine_test.cpp
@@ -102,6 +102,7 @@ int main() {
 	fin_vmstub.close();
 	fin_vmproj.close();
 	fin_candmatch.close();
+
         // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
         if (err_count > 255) err_count = 255;
 	return err_count;

--- a/TestBenches/ProjectionRouter_test.cpp
+++ b/TestBenches/ProjectionRouter_test.cpp
@@ -118,48 +118,55 @@ int main()
     BXType bx = ievt;
     BXType bx_out;
 
+    // Clear output memories
+    allproj.clear();
+    for (unsigned int imem = 0; imem<8; imem++) {
+      vmprojarray[imem].clear();
+    }
+
     // Unit Under Test
     ProjectionRouterTop(bx, tprojarray, bx_out, allproj, vmprojarray);
 
     // compare the computed outputs with the expected ones
-    bool truncation = false;
+    bool truncation = true;
     // AllProjection
     err += compareMemWithFile<AllProjectionMemory<BARRELPS> >
-      (allproj,fout_aproj, ievt, "AllProjection", truncation, kMaxProc-10);
+      (allproj,fout_aproj, ievt, "AllProjection", truncation);
     // VMProjection1
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[0], fout_vmproj1, ievt, "VMProjection1", truncation, kMaxProc-10);
+      (vmprojarray[0], fout_vmproj1, ievt, "VMProjection1", truncation);
 
     // VMProjection2
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[1], fout_vmproj2, ievt, "VMProjection2", truncation, kMaxProc-10);
+      (vmprojarray[1], fout_vmproj2, ievt, "VMProjection2", truncation);
 
     // VMProjection3
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[2], fout_vmproj3, ievt, "VMProjection3", truncation, kMaxProc-10);
+      (vmprojarray[2], fout_vmproj3, ievt, "VMProjection3", truncation);
 
     // VMProjection4
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[3], fout_vmproj4, ievt, "VMProjection4", truncation, kMaxProc-10);
+      (vmprojarray[3], fout_vmproj4, ievt, "VMProjection4", truncation);
 
     // VMProjection5
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[4], fout_vmproj5, ievt, "VMProjection5", truncation, kMaxProc-10);
+      (vmprojarray[4], fout_vmproj5, ievt, "VMProjection5", truncation);
 
     // VMProjection6
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[5], fout_vmproj6, ievt, "VMProjection6", truncation, kMaxProc-10);
+      (vmprojarray[5], fout_vmproj6, ievt, "VMProjection6", truncation);
 
     // VMProjection7
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[6], fout_vmproj7, ievt, "VMProjection7", truncation, kMaxProc-10);
+      (vmprojarray[6], fout_vmproj7, ievt, "VMProjection7", truncation);
 
     // VMProjection8
     err += compareMemWithFile<VMProjectionMemory<BARREL> >
-      (vmprojarray[7], fout_vmproj8, ievt, "VMProjection8", truncation, kMaxProc-10);
+      (vmprojarray[7], fout_vmproj8, ievt, "VMProjection8", truncation);
     
   } // end of event loop
-  
+  // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+  if (err > 255) err = 255;
   return err;
   
 }

--- a/TestBenches/ProjectionRouter_test.cpp
+++ b/TestBenches/ProjectionRouter_test.cpp
@@ -165,6 +165,7 @@ int main()
       (vmprojarray[7], fout_vmproj8, ievt, "VMProjection8", truncation);
     
   } // end of event loop
+  
   // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
   if (err > 255) err = 255;
   return err;

--- a/TestBenches/TrackletCalculator_L1L2E_test.cpp
+++ b/TestBenches/TrackletCalculator_L1L2E_test.cpp
@@ -167,6 +167,15 @@ int main()
   for (unsigned int ievt = 0; ievt < nevents; ++ievt) {
     cout << "Event: " << dec << ievt << endl;
 
+    // Clear all output memories before starting.
+    tpar.clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_BARRELPS; i++)
+      tproj_barrel_ps[i].clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_BARREL2S; i++)
+      tproj_barrel_2s[i].clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_DISK; i++)
+      tproj_disk[i].clear();
+
     // read event and write to memories
     writeMemFromFile<AllStubMemory<BARRELPS> >(innerStubs[0], fin_innerStubs0, ievt);
     writeMemFromFile<AllStubMemory<BARRELPS> >(innerStubs[1], fin_innerStubs1, ievt);
@@ -253,6 +262,8 @@ int main()
 
   } // end of event loop
 
+  // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+  if (err > 255) err = 255;
   return err;
 
 }

--- a/TestBenches/TrackletCalculator_L1L2G_test.cpp
+++ b/TestBenches/TrackletCalculator_L1L2G_test.cpp
@@ -160,6 +160,15 @@ int main()
   for (unsigned int ievt = 0; ievt < nevents; ++ievt) {
     cout << "Event: " << dec << ievt << endl;
 
+    // Clear all output memories before starting.
+    tpar.clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_BARRELPS; i++)
+      tproj_barrel_ps[i].clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_BARREL2S; i++)
+      tproj_barrel_2s[i].clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_DISK; i++)
+      tproj_disk[i].clear();    
+
     // read event and write to memories
     writeMemFromFile<AllStubMemory<BARRELPS> >(innerStubs[0], fin_innerStubs, ievt);
     writeMemFromFile<AllStubMemory<BARRELPS> >(outerStubs[0], fin_outerStubs0, ievt);
@@ -242,6 +251,8 @@ int main()
 
   } // end of event loop
 
+  // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+  if (err > 255) err = 255;
   return err;
 
 }

--- a/TestBenches/TrackletCalculator_L3L4E_test.cpp
+++ b/TestBenches/TrackletCalculator_L3L4E_test.cpp
@@ -127,6 +127,15 @@ int main()
   for (unsigned int ievt = 0; ievt < nevents; ++ievt) {
     cout << "Event: " << dec << ievt << endl;
 
+    // Clear all output memories before starting.
+    tpar.clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_BARRELPS; i++)
+      tproj_barrel_ps[i].clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_BARREL2S; i++)
+      tproj_barrel_2s[i].clear();
+    for (unsigned i = 0; i < TC::N_PROJOUT_DISK; i++)
+      tproj_disk[i].clear();
+
     // read event and write to memories
     writeMemFromFile<AllStubMemory<BARRELPS> >(innerStubs[0], fin_innerStubs, ievt);
     writeMemFromFile<AllStubMemory<BARREL2S> >(outerStubs[0], fin_outerStubs0, ievt);
@@ -189,6 +198,8 @@ int main()
 
   } // end of event loop
 
+  // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+  if (err > 255) err = 255;
   return err;
 
 }

--- a/TestBenches/TrackletEngine_test.cpp
+++ b/TestBenches/TrackletEngine_test.cpp
@@ -46,6 +46,8 @@ int main(){
   for (int ievt = 0; ievt < nevents; ++ievt) {
     cout << "Event: " << dec << ievt << endl;
 
+    outputstubpairs.clear();
+
     //read next event from the input files
     writeMemFromFile<VMStubTEInnerMemory<BARRELPS> >(inputvmstubsinner, fin_vmstubsinner,ievt);
     writeMemFromFile<VMStubTEOuterMemory<BARRELPS> >(inputvmstubsouter, fin_vmstubsouter,ievt);
@@ -66,6 +68,8 @@ int main(){
   fin_vmstubsinner.close();
   fin_vmstubsouter.close();
   fin_stubpairs.close();
-  
+
+  // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+  if (err_count > 255) err_count = 255;  
   return err_count;
 }

--- a/TestBenches/TrackletEngine_test.cpp
+++ b/TestBenches/TrackletEngine_test.cpp
@@ -68,8 +68,8 @@ int main(){
   fin_vmstubsinner.close();
   fin_vmstubsouter.close();
   fin_stubpairs.close();
-
+  
   // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
-  if (err_count > 255) err_count = 255;  
+  if (err_count > 255) err_count = 255;
   return err_count;
 }

--- a/TestBenches/VMRouter_test.cpp
+++ b/TestBenches/VMRouter_test.cpp
@@ -209,6 +209,24 @@ int main()
   for (unsigned int ievt = 0; ievt < nevents; ++ievt) {
     cout << "Event: " << dec << ievt << endl;
 
+  // clear output memories
+  for (int i=0; i<6; ++i) {
+    allStub[i].clear();
+  }
+  for (int i=0; i<4; ++i) {
+    meMemories[i].clear();
+  }
+  for (int i=0; i<4; ++i) {
+    for (int j=0; j<5; j++) {
+      teiMemories[i][j].clear();
+    }
+  }
+  for (int i=0; i<2; ++i) {
+    for (int j=0; j<3; j++) {
+      olMemories[i][j].clear();
+    }
+  }
+
   // read event and write to memories
   writeMemFromFile<InputStubMemory<BARRELPS>>(inputStub[0], fin_inputstub1, ievt);
   writeMemFromFile<InputStubMemory<BARRELPS>>(inputStub[1], fin_inputstub2, ievt);
@@ -292,6 +310,8 @@ int main()
   } // end of event loop
 
 	std::cerr << "Exiting with return value " << err << std::endl;
+        // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+        if (err > 255) err = 255;
 	return err;
 
 }

--- a/TestBenches/VMRouter_test.cpp
+++ b/TestBenches/VMRouter_test.cpp
@@ -310,8 +310,8 @@ int main()
   } // end of event loop
 
 	std::cerr << "Exiting with return value " << err << std::endl;
-        // This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
-        if (err > 255) err = 255;
+	// This is necessary because HLS seems to only return an 8-bit error count, so if err%256==0, the test bench can falsely pass
+	if (err > 255) err = 255;
 	return err;
 
 }

--- a/TestBenches/VMRouter_test_D1PHIA.cpp
+++ b/TestBenches/VMRouter_test_D1PHIA.cpp
@@ -285,6 +285,24 @@ int main()
   for (unsigned int ievt = 0; ievt < nevents; ++ievt) {
     cout << "Event: " << dec << ievt << endl;
 
+  // clear output memories
+  for (int i=0; i<6; ++i) {
+    allStub[i].clear();
+  }
+  for (int i=0; i<8; ++i) {
+    meMemories[i].clear();
+  }
+  for (int i=0; i<4; ++i) {
+    for (int j=0; j<3; j++) {
+      teiMemories[i][j].clear();
+    }
+  }
+  for (int i=0; i<4; ++i) {
+    for (int j=0; j<5; j++) {
+      teoMemories[i][j].clear();
+    }
+  }
+
   // read event and write to memories
   writeMemFromFile<InputStubMemory<DISK2S>>(inputStubDisk2S[0], fin_inputstub1, ievt);
   writeMemFromFile<InputStubMemory<DISKPS>>(inputStub[0], fin_inputstub2, ievt);

--- a/TrackletAlgorithm/MatchCalculator.h
+++ b/TrackletAlgorithm/MatchCalculator.h
@@ -795,18 +795,7 @@ void MatchCalculator(BXType bx,
       projseed_next  = projseed;
     }
 
-    if (istep==0){
-      // Reset output memories
-      fullmatch[0].clear(bx);
-      fullmatch[1].clear(bx);
-      fullmatch[2].clear(bx);
-      fullmatch[3].clear(bx);
-      fullmatch[4].clear(bx);
-      fullmatch[5].clear(bx);
-      fullmatch[6].clear(bx);
-      fullmatch[7].clear(bx);
-    }
-    else if(newtracklet && goodmatch==true) { // Write out only the best match, based on the seeding 
+    if(newtracklet && goodmatch==true) { // Write out only the best match, based on the seeding 
       switch (projseed) {
       case 0:
       fullmatch[0].write_mem(bx,bestmatch,nmcout1);//(newtracklet && goodmatch==true && projseed==0)); // L1L2 seed

--- a/TrackletAlgorithm/MatchEngine.cc
+++ b/TrackletAlgorithm/MatchEngine.cc
@@ -77,7 +77,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 	// Seven iterations are subtracted so that the total latency is 108 clock
 	// cycles. Pipeline rewinding does not currently work.
 	STEP_LOOP: for (ap_uint<kNBits_MemAddr> istep=0; istep<kMaxProc - kMaxProcOffset(module::ME); istep++) {
-		#pragma HLS PIPELINE II=1
+		#pragma HLS PIPELINE II=1 rewind
 		#pragma HLS DEPENDENCE variable=tail_readindex inter false
 
 		// Pre-fetch an element from the buffer

--- a/TrackletAlgorithm/MatchEngine.cc
+++ b/TrackletAlgorithm/MatchEngine.cc
@@ -36,8 +36,6 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 	ap_uint<1> table[LSIZE];
 	readTable(table);
 
-	outputCandidateMatch.clear(bx);
-
 	//
 	// Set up a FIFO based on a circular buffer structure.
 	// Projection memory is read and if projections points to nonempty zbin for the stubs it is stored on this buffer.

--- a/TrackletAlgorithm/MatchEngine.h
+++ b/TrackletAlgorithm/MatchEngine.h
@@ -73,7 +73,7 @@
 #define LSIZE RINVSTEPS*(1<<VMStubME<MODULETYPE>::kVMSMEBendSize)
 #define BUFFERSIZE 8
 constexpr unsigned int kNBits_BufferAddr=BITS_TO_REPRESENT(BUFFERSIZE-1);
-constexpr int kBufferDataSize = VMStubMEMemory<MODULETYPE,NBITBIN>::kNBitData   // number of bits for stubs array size
+constexpr int kBufferDataSize = VMStubMEMemory<MODULETYPE,NBITBIN>::kNBitDataAddr   // number of bits for stubs array size
 							  + VMProjection<PROJECTIONTYPE>::kVMProjectionSize	// projection data size
 							  + MEBinsBits										// number of bits for index of z-bin
 							  + 1;												// z-bin flag (0 => first bin, 1 => second bin)
@@ -87,7 +87,7 @@ namespace ME {
 		kVMMEProjectionLSB = kVMMEZBinMSB + 1,
 		kVMMEProjectionMSB = kVMMEProjectionLSB + VMProjection<PROJECTIONTYPE>::kVMProjectionSize - 1,
 		kVMMENStubsLSB = kVMMEProjectionMSB + 1,
-		kVMMENStubsMSB = kVMMENStubsLSB + VMStubMEMemory<MODULETYPE,NBITBIN>::kNBitData - 1
+		kVMMENStubsMSB = kVMMENStubsLSB + VMStubMEMemory<MODULETYPE,NBITBIN>::kNBitDataAddr - 1
 	};
 	enum StubZPositionBarrelConsistency {
 		kPSMin = -2,

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -31,15 +31,15 @@ public:
 
   NEntryT getEntries(BunchXingT bx) const {
 #pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-       return nentries_[bx];
+	return nentries_[bx];
   }
 
   const DataType (&get_mem() const)[1<<NBIT_BX][1<<NBIT_ADDR] {return dataarray_;}
 
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index) const
   {
-       // TODO: check if valid
-       return dataarray_[ibx][index];
+	// TODO: check if valid
+	return dataarray_[ibx][index];
   }
 
   template<class SpecType>
@@ -89,18 +89,18 @@ public:
   // write memory from text file
   bool write_mem(BunchXingT ibx, const char* datastr, int base=16)
   {
-     DataType data(datastr, base);
-     int nent = nentries_[ibx]; 
-     bool success = write_mem(ibx, data, nent);
-     if (success) nentries_[ibx] ++;
+	DataType data(datastr, base);
+	int nent = nentries_[ibx]; 
+	bool success = write_mem(ibx, data, nent);
+	if (success) nentries_[ibx] ++;
   }
 
   bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
   {
-    DataType data(datastr.c_str(), base);
-    int nent = nentries_[ibx];
-    bool success = write_mem(ibx, data, nent);
-    if (success) nentries_[ibx] ++;
+	DataType data(datastr.c_str(), base);
+	int nent = nentries_[ibx];
+	bool success = write_mem(ibx, data, nent);
+	if (success) nentries_[ibx] ++;
   }
 
   // print memory contents
@@ -117,25 +117,26 @@ public:
 
   void print_mem(BunchXingT bx) const
   {
-       for (int i = 0; i <  nentries_[bx]; ++i) {
-         std::cout << bx << " " << i << " ";
-         print_entry(bx,i);
-       }
+	for (int i = 0; i <  nentries_[bx]; ++i) {
+	  std::cout << bx << " " << i << " ";
+	  print_entry(bx,i);
+	}
   }
 
   void print_mem() const
   {
-       for (int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
-         for (int i = 0; i < nentries_[ibx]; ++i) {
-               std::cout << ibx << " " << i << " ";
-               print_entry(ibx,i);
-         }
-       }
+	for (int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
+	  for (int i = 0; i < nentries_[ibx]; ++i) {
+		std::cout << ibx << " " << i << " ";
+		print_entry(ibx,i);
+	  }
+	}
   }
 
   static constexpr int getWidth() {return DataType::getWidth();}
   
 #endif
+  
 };
 
 #endif

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -15,63 +15,36 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR>
 class MemoryTemplate
 {
 public:
-  static constexpr unsigned int kNBitAddr = NBIT_ADDR;
-  static constexpr unsigned int kNBitData = kNBitAddr+1;
   typedef typename DataType::BitWidths BitWidths;
   typedef ap_uint<NBIT_BX> BunchXingT;
-  typedef ap_uint<kNBitData> NEntryT;
+  typedef ap_uint<NBIT_ADDR> NEntryT;
   
 protected:
 
-  DataType dataarray_[1<<NBIT_BX][1<<kNBitAddr];  // data array
+  DataType dataarray_[1<<NBIT_BX][1<<NBIT_ADDR];  // data array
   NEntryT nentries_[1<<NBIT_BX];                  // number of entries
   
 public:
 
-  MemoryTemplate()
-  {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-	clear();
-  }
-
-  ~MemoryTemplate(){}
-
-  void clear()
-  {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-#pragma HLS inline
-  MEM_RST: for (size_t ibx=0; ibx<(1<<NBIT_BX); ++ibx) {
-#pragma HLS UNROLL
-	  nentries_[ibx] = 0;
-	}
-  }
-
-  void clear(BunchXingT bx) {
-#pragma HLS inline
-    nentries_[bx] = 0;
-  }
-
-  unsigned int getDepth() const {return (1<<kNBitAddr);}
+  unsigned int getDepth() const {return (1<<NBIT_ADDR);}
   unsigned int getNBX() const {return (1<<NBIT_BX);}
 
   NEntryT getEntries(BunchXingT bx) const {
 #pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-	return nentries_[bx];
+       return nentries_[bx];
   }
 
-  const DataType (&get_mem() const)[1<<NBIT_BX][1<<kNBitAddr] {return dataarray_;}
+  const DataType (&get_mem() const)[1<<NBIT_BX][1<<NBIT_ADDR] {return dataarray_;}
 
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index) const
   {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-	// TODO: check if valid
-	return dataarray_[ibx][index];
+       // TODO: check if valid
+       return dataarray_[ibx][index];
   }
 
   template<class SpecType>
   bool write_mem(BunchXingT ibx, SpecType data, int addr_index)
   {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
 #pragma HLS inline
     static_assert(
       std::is_same<DataType, SpecType>::value
@@ -84,11 +57,9 @@ public:
 
   bool write_mem(BunchXingT ibx, DataType data, int addr_index)
   {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
 #pragma HLS inline
-    if (addr_index < (1<<kNBitAddr)) {
+    if (addr_index < (1<<NBIT_ADDR)) {
       dataarray_[ibx][addr_index] = data;
-      nentries_[ibx] = addr_index + 1;
       return true;
     } else {
       return false;
@@ -97,21 +68,39 @@ public:
 
   // Methods for C simulation only
 #ifndef __SYNTHESIS__
-  
+  MemoryTemplate()
+  {
+       clear();
+  }
+
+  ~MemoryTemplate(){}
+
+  void clear()
+  {
+    DataType data("0",16);
+    MEM_RST: for (size_t ibx=0; ibx<(1<<NBIT_BX); ++ibx) {
+      nentries_[ibx] = 0;
+      for (size_t addr=0; addr<(1<<NBIT_ADDR); ++addr) {
+        write_mem(ibx,data,addr);
+      }
+    }
+  }
+
   // write memory from text file
   bool write_mem(BunchXingT ibx, const char* datastr, int base=16)
   {
-	DataType data(datastr, base);
-        int nent = nentries_[ibx];
-	// std::cout << "write_mem " << data << std::endl;
-	return write_mem(ibx, data, nent);
+     DataType data(datastr, base);
+     int nent = nentries_[ibx]; 
+     bool success = write_mem(ibx, data, nent);
+     if (success) nentries_[ibx] ++;
   }
+
   bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
   {
     DataType data(datastr.c_str(), base);
-        int nent = nentries_[ibx];
-	// std::cout << "write_mem " << data << std::endl;
-	return write_mem(ibx, data, nent);
+    int nent = nentries_[ibx];
+    bool success = write_mem(ibx, data, nent);
+    if (success) nentries_[ibx] ++;
   }
 
   // print memory contents
@@ -128,26 +117,25 @@ public:
 
   void print_mem(BunchXingT bx) const
   {
-	for (int i = 0; i <  nentries_[bx]; ++i) {
-	  std::cout << bx << " " << i << " ";
-	  print_entry(bx,i);
-	}
+       for (int i = 0; i <  nentries_[bx]; ++i) {
+         std::cout << bx << " " << i << " ";
+         print_entry(bx,i);
+       }
   }
 
   void print_mem() const
   {
-	for (int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
-	  for (int i = 0; i < nentries_[ibx]; ++i) {
-		std::cout << ibx << " " << i << " ";
-		print_entry(ibx,i);
-	  }
-	}
+       for (int ibx = 0; ibx < (1<<NBIT_BX); ++ibx) {
+         for (int i = 0; i < nentries_[ibx]; ++i) {
+               std::cout << ibx << " " << i << " ";
+               print_entry(ibx,i);
+         }
+       }
   }
 
   static constexpr int getWidth() {return DataType::getWidth();}
   
 #endif
-  
 };
 
 #endif

--- a/TrackletAlgorithm/MemoryTemplate.h
+++ b/TrackletAlgorithm/MemoryTemplate.h
@@ -93,6 +93,7 @@ public:
 	int nent = nentries_[ibx]; 
 	bool success = write_mem(ibx, data, nent);
 	if (success) nentries_[ibx] ++;
+        return success;
   }
 
   bool write_mem(BunchXingT ibx, const std::string datastr, int base=16)
@@ -101,6 +102,7 @@ public:
 	int nent = nentries_[ibx];
 	bool success = write_mem(ibx, data, nent);
 	if (success) nentries_[ibx] ++;
+        return success;
   }
 
   // print memory contents

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -79,7 +79,7 @@ public:
 
   // Methods for C simulation only
 #ifndef __SYNTHESIS__
-
+  
   MemoryTemplateBinned()
   {
         clear();

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -13,16 +13,15 @@ template<class DataType, unsigned int NBIT_BX, unsigned int NBIT_ADDR,
 		 unsigned int NBIT_BIN>
 // DataType: type of data object stored in the array
 // NBIT_BX: number of bits for BX;
-// (1<<NBIT_BIN): number of BXs the memory is keeping track of
+// (1<<NBIT_BX): number of BXs the memory is keeping track of
 // NBIT_ADDR: number of bits for memory address space per BX
 // (1<<NBIT_ADDR): depth of the memory for each BX
 // NBIT_BIN: number of bits used for binning; (1<<NBIT_BIN): number of bins
 class MemoryTemplateBinned{
 public:
   static constexpr unsigned int kNBitDataAddr = NBIT_ADDR-NBIT_BIN;
-  static constexpr unsigned int kNBitData = kNBitDataAddr+1;
   typedef ap_uint<NBIT_BX> BunchXingT;
-  typedef ap_uint<kNBitData> NEntryT;
+  typedef ap_uint<kNBitDataAddr> NEntryT;
   
 protected:
   enum BitWidths {
@@ -36,83 +35,37 @@ protected:
   
 public:
 
-  MemoryTemplateBinned()
-  {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-	clear();
-  }
-  
-  ~MemoryTemplateBinned(){}
-  
-  void clear()
-  {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-#pragma HLS inline
-	
-	for (size_t ibx=0; ibx<(kNBxBins); ++ibx) {
-#pragma HLS UNROLL
-	  clear(ibx);
-	}
-  }
-
-  void clear(BunchXingT bx)
-  {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-#pragma HLS inline
-	
-	for (unsigned int ibin = 0; ibin < (kNSlots); ++ibin) {
-#pragma HLS UNROLL
-	  nentries_[bx][ibin] = 0;
-	}
-  }
-
   unsigned int getDepth() const {return kNMemDepth;}
   unsigned int getNBX() const {return kNBxBins;}
   unsigned int getNBins() const {return kNSlots;}
+  unsigned int getNEntryPerBin() const {return (1<<(kNBitDataAddr));}
 
   NEntryT getEntries(BunchXingT bx, ap_uint<NBIT_BIN> ibin) const {
 #pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
 	return nentries_[bx][ibin];
   }
 
-  NEntryT getEntries(BunchXingT bx) const {
-    NEntryT val = 0;
-    for ( auto i = 0; i < getDepth(); ++i ) {
-      val += getEntries(bx, i);
-    }
-    return val;
-  }
-
-
   const DataType (&get_mem() const)[1<<NBIT_BX][1<<NBIT_ADDR] {return dataarray_;}
 
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_ADDR> index) const
   {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-	// TODO: check if valid
-	return dataarray_[ibx][index];
+    // TODO: check if valid
+    return dataarray_[ibx][index];
   }
   
   DataType read_mem(BunchXingT ibx, ap_uint<NBIT_BIN> slot,
 		    ap_uint<NBIT_ADDR> index) const
   {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
     // TODO: check if valid
     return dataarray_[ibx][(1<<(kNBitDataAddr))*slot+index];
   }
 
-  bool write_mem(BunchXingT ibx, ap_uint<NBIT_BIN> slot, DataType data)
+  bool write_mem(BunchXingT ibx, ap_uint<NBIT_BIN> slot, DataType data, int nentry_ibx)
   {
-#pragma HLS ARRAY_PARTITION variable=nentries_ complete dim=0
-#pragma HLS dependence variable=nentries_ intra WAR true
 #pragma HLS inline
-
-	NEntryT nentry_ibx = nentries_[ibx][slot];
-
 	if (nentry_ibx < (1<<(kNBitDataAddr))) {
 	  // write address for slot: 1<<(kNBitDataAddr) * slot + nentry_ibx
 	  dataarray_[ibx][(1<<(kNBitDataAddr))*slot+nentry_ibx] = data;
-	  nentries_[ibx][slot] = nentry_ibx + 1;
 	  return true;
 	}
 	else {
@@ -126,7 +79,27 @@ public:
 
   // Methods for C simulation only
 #ifndef __SYNTHESIS__
-  
+
+  MemoryTemplateBinned()
+  {
+        clear();
+  }
+
+  ~MemoryTemplateBinned(){}
+
+  void clear()
+  {
+    DataType data("0",16);
+    for (size_t ibx=0; ibx<kNBxBins; ++ibx) {
+      for (size_t ibin=0; ibin<kNSlots; ++ibin) {
+        nentries_[ibx][ibin] = 0;
+        for (size_t addr=0; addr<(1<<(kNBitDataAddr)); ++addr) {
+          write_mem(ibx,ibin,data,addr);
+        }
+      }
+    }
+  }
+
   ///////////////////////////////////
   std::vector<std::string> split(const std::string& s, char delimiter)
   {
@@ -150,8 +123,9 @@ public:
     // Originally: atoi(split(line, ' ').front().c_str()); but that didn't work for disks with 16 bins
 
     DataType data(datastr.c_str(), base);
-    //std::cout << "write_mem slot data : " << slot<<" "<<data << std::endl;
-    return write_mem(bx, slot, data);
+    int nent = nentries_[bx][slot];
+    bool success = write_mem(bx, slot, data, nent);
+    if (success) nentries_[bx][slot] ++;
   }
 
 
@@ -170,13 +144,11 @@ public:
   void print_mem(BunchXingT bx) const
   {
 	for(int slot=0;slot<(kNSlots);slot++) {
-      //std::cout << "slot "<<slot<<" entries "
-      //		<<nentries_[bx%NBX].range((slot+1)*4-1,slot*4)<<endl;
-      for (int i = 0; i < nentries_[bx][slot]; ++i) {
+	  for (int i = 0; i < nentries_[bx][slot]; ++i) {
 		std::cout << bx << " " << i << " ";
 		print_entry(bx, i + slot*(1<<(kNBitDataAddr)) );
-      }
-    }
+ 	  }
+	}
   }
 
   void print_mem() const

--- a/TrackletAlgorithm/MemoryTemplateBinned.h
+++ b/TrackletAlgorithm/MemoryTemplateBinned.h
@@ -126,6 +126,7 @@ public:
     int nent = nentries_[bx][slot];
     bool success = write_mem(bx, slot, data, nent);
     if (success) nentries_[bx][slot] ++;
+    return success;
   }
 
 

--- a/TrackletAlgorithm/ProjectionRouter.h
+++ b/TrackletAlgorithm/ProjectionRouter.h
@@ -93,12 +93,11 @@ void ProjectionRouter(BXType bx,
       // reset output memories & counters
       nallproj = 0;
 #pragma HLS ARRAY_PARTITION variable=nvmprojout complete dim=0
-      allprojout.clear(bx);
       for (int i=0; i<nOUTMEM; i++) {
 #pragma HLS unroll
-        vmprojout[i].clear(bx);
         nvmprojout[i] = 0;
       }
+
       // check the number of entries in the input memories
       // fill the bit mask indicating if memories are empty or not
       mem_hasdata = 0;

--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -567,15 +567,27 @@ TrackletCalculator(
 {
   static_assert(Seed == TF::L1L2 || Seed == TF::L3L4 || Seed == TF::L5L6, "Only L1L2, L3L4, and L5L6 seeds have been implemented so far.");
 
-  int npar;
+  int npar = 0;
   int nproj_barrel_ps[TC::N_PROJOUT_BARRELPS];
   int nproj_barrel_2s[TC::N_PROJOUT_BARREL2S];
   int nproj_disk[TC::N_PROJOUT_DISK];
 #pragma HLS array_partition variable=nproj_barrel_ps complete
 #pragma HLS array_partition variable=nproj_barrel_2s complete
 #pragma HLS array_partition variable=nproj_disk complete
+  for (unsigned i = 0; i < TC::N_PROJOUT_BARRELPS; i++) {
+#pragma HLS unroll
+    nproj_barrel_ps[i] = 0;
+  }
+  for (unsigned i = 0; i < TC::N_PROJOUT_BARREL2S; i++) {
+#pragma HLS unroll
+    nproj_barrel_2s[i] = 0;
+  }
+  for (unsigned i = 0; i < TC::N_PROJOUT_DISK; i++) {
+#pragma HLS unroll
+    nproj_disk[i] = 0;
+  }
 
-  TrackletProjection<BARRELPS>::TProjTrackletIndex trackletIndex;
+  TrackletProjection<BARRELPS>::TProjTrackletIndex trackletIndex = 0;
 
   const TrackletProjection<BARRELPS>::TProjTCID TCID = TC::ID<Seed, iTC>();
 
@@ -586,29 +598,20 @@ TrackletCalculator(
 // The first iteration is sacrificed to clearing the output memories and
 // zeroing the number of tracklets and projections. Therefore, only
 // kMaxProc - 1 iterations are actually used for processing stub pairs.
-    if (i == 0) {
-      npar = 0;
-      memset(nproj_barrel_ps, 0, sizeof(int) * TC::N_PROJOUT_BARRELPS);
-      memset(nproj_barrel_2s, 0, sizeof(int) * TC::N_PROJOUT_BARREL2S);
-      memset(nproj_disk, 0, sizeof(int) * TC::N_PROJOUT_DISK);
-      trackletIndex = 0;
-    }
-    else {
-      TC::Types::nSPMem iSPMem;
-      TC::Types::nSP iSP = i - 1;
-      bool done;
-      TC::getIndices<NSPMem>(bx, stubPairs, iSPMem, iSP, done);
+    TC::Types::nSPMem iSPMem;
+    TC::Types::nSP iSP = i - 1;
+    bool done;
+    TC::getIndices<NSPMem>(bx, stubPairs, iSPMem, iSP, done);
 
-      if (!done) {
+    if (!done) {
 // Retrieve the inner and outer stubs for this stub pair, determining which
 // all-stubs memory to use based on iSPMem:
-        const StubPair::SPInnerIndex innerIndex = stubPairs[iSPMem].read_mem(bx, iSP).getInnerIndex();
-        const StubPair::SPOuterIndex outerIndex = stubPairs[iSPMem].read_mem(bx, iSP).getOuterIndex();
-        const AllStub<InnerRegion> &innerStub = innerStubs[(ASInnerMask<Seed, iTC>() & (1 << iSPMem)) >> iSPMem].read_mem(bx, innerIndex);
-        const AllStub<OuterRegion> &outerStub = outerStubs[(ASOuterMask<Seed, iTC>() & (1 << iSPMem)) >> iSPMem].read_mem(bx, outerIndex);
+      const StubPair::SPInnerIndex innerIndex = stubPairs[iSPMem].read_mem(bx, iSP).getInnerIndex();
+      const StubPair::SPOuterIndex outerIndex = stubPairs[iSPMem].read_mem(bx, iSP).getOuterIndex();
+      const AllStub<InnerRegion> &innerStub = innerStubs[(ASInnerMask<Seed, iTC>() & (1 << iSPMem)) >> iSPMem].read_mem(bx, innerIndex);
+      const AllStub<OuterRegion> &outerStub = outerStubs[(ASOuterMask<Seed, iTC>() & (1 << iSPMem)) >> iSPMem].read_mem(bx, outerIndex);
 
-        TC::processStubPair<Seed, InnerRegion, OuterRegion, TPROJMaskBarrel<Seed, iTC>(), TPROJMaskDisk<Seed, iTC>()>(bx, innerIndex, innerStub, outerIndex, outerStub, TCID, trackletIndex, trackletParameters, projout_barrel_ps, projout_barrel_2s, projout_disk, npar, nproj_barrel_ps, nproj_barrel_2s, nproj_disk);
-      }
+      TC::processStubPair<Seed, InnerRegion, OuterRegion, TPROJMaskBarrel<Seed, iTC>(), TPROJMaskDisk<Seed, iTC>()>(bx, innerIndex, innerStub, outerIndex, outerStub, TCID, trackletIndex, trackletParameters, projout_barrel_ps, projout_barrel_2s, projout_disk, npar, nproj_barrel_ps, nproj_barrel_2s, nproj_disk);
     }
   }
 }

--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -591,18 +591,6 @@ TrackletCalculator(
       memset(nproj_barrel_ps, 0, sizeof(int) * TC::N_PROJOUT_BARRELPS);
       memset(nproj_barrel_2s, 0, sizeof(int) * TC::N_PROJOUT_BARREL2S);
       memset(nproj_disk, 0, sizeof(int) * TC::N_PROJOUT_DISK);
-
-      trackletParameters->clear(bx);
-      clear_barrel_ps: for (unsigned j = 0; j < TC::N_PROJOUT_BARRELPS; j++)
-        if (TPROJMaskBarrel<Seed, iTC>() & (0x1 << j))
-          projout_barrel_ps[j].clear(bx);
-      clear_barrel_2s: for (unsigned j = 0; j < TC::N_PROJOUT_BARREL2S; j++)
-        if (TPROJMaskBarrel<Seed, iTC>() & (0x1 << (j + TC::N_PROJOUT_BARRELPS)))
-          projout_barrel_2s[j].clear(bx);
-      clear_disk: for (unsigned j = 0; j < TC::N_PROJOUT_DISK; j++)
-        if (TPROJMaskDisk<Seed, iTC>() & (0x1 << j))
-          projout_disk[j].clear(bx);
-
       trackletIndex = 0;
     }
     else {

--- a/TrackletAlgorithm/TrackletEngine.h
+++ b/TrackletAlgorithm/TrackletEngine.h
@@ -52,8 +52,6 @@ void TrackletEngine(
   int nstubpairs = 0;
 #pragma HLS dependence variable=nstubpairs intra WAR true
 
-  outstubpair.clear(bx);
-
   //
   // Set up a FIFO based on a circular buffer structure
   // Each element consists of

--- a/TrackletAlgorithm/TrackletEngine.h
+++ b/TrackletAlgorithm/TrackletEngine.h
@@ -106,7 +106,7 @@ void TrackletEngine(
   // Seven iterations are subtracted so that the total latency is 108 clock
   // cycles. Pipeline rewinding does not currently work.
   for (unsigned int istep=0; istep<kMaxProc - kMaxProcOffset(module::TE); istep++) {
-#pragma HLS pipeline II=1
+#pragma HLS pipeline II=1 rewind
 
 	  // pre-fetch element from buffer
 	  auto const bufdata = teBuffer[readindex];

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -561,7 +561,7 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 	// Create variables that keep track of which memory address to read and write to
 
 	ap_uint<kNBits_MemAddr> read_addr(0); // Reading of input stubs
-	
+
 	int addrCountME[nvmme][nmaxbinsperpage]; // Writing of ME stubs
 	if (memask) {
 		#pragma HLS array_partition variable=addrCountME complete dim=0
@@ -608,7 +608,7 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 			#pragma HLS UNROLL
 			for (int j = 0; j < MaxOLCopies; j++) {
 				#pragma HLS UNROLL
-					addrCountOL[i][j] = 0;
+				addrCountOL[i][j] = 0;
 			}
 		}
 }

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -562,7 +562,7 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 
 	ap_uint<kNBits_MemAddr> read_addr(0); // Reading of input stubs
 
-	int addrCountME[nvmme][nmaxbinsperpage]; // Writing of ME stubs
+	ap_uint<kNBits_MemAddr> addrCountME[nvmme][nmaxbinsperpage]; // Writing of ME stubs
 	if (memask) {
 		#pragma HLS array_partition variable=addrCountME complete dim=0
 		ADDR_ME:	for (int i = 0; i < nvmme; i++) {
@@ -574,7 +574,7 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 		}
 	}
 
-	int addrCountTEI[nvmte][MaxTEICopies]; // Writing of TE Inner stubs
+	ap_uint<kNBits_MemAddr> addrCountTEI[nvmte][MaxTEICopies]; // Writing of TE Inner stubs
 	if (teimask) {
 		#pragma HLS array_partition variable=addrCountTEI complete dim=0
 		ADDR_TEI:	for (int i = 0; i < nvmte; i++) {
@@ -586,7 +586,7 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 		}
 	}
 
-	int addrCountTEO[nvmte][MaxTEOCopies][nmaxbinsperpage]; // Writing of TE Outer stubs
+	ap_uint<kNBits_MemAddr> addrCountTEO[nvmte][MaxTEOCopies][nmaxbinsperpage]; // Writing of TE Outer stubs
 	if (teomask) {
 		#pragma HLS array_partition variable=addrCountTEO complete dim=0
 		ADDR_TEO:	for (int i = 0; i < nvmte; i++) {
@@ -601,7 +601,7 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 		}
 	}
 
-	int addrCountOL[nvmol][MaxOLCopies]; // Writing of TE Overlap stubs
+	ap_uint<kNBits_MemAddr> addrCountOL[nvmol][MaxOLCopies]; // Writing of TE Overlap stubs
 	if (olmask) {
 	#pragma HLS array_partition variable=addrCountOL complete dim=0
 	ADDR_OL:	for (int i = 0; i < nvmol; i++) {

--- a/TrackletAlgorithm/VMRouter.h
+++ b/TrackletAlgorithm/VMRouter.h
@@ -56,6 +56,8 @@ constexpr int nbitsrtabledisk = 8;
 // Number of MSBs used for r index in phicorr LUTs
 constexpr int nrbitsphicorrtable = 3; // Found hardcoded in VMRouterphicorrtable.h
 
+constexpr int nmaxbinsperpage = 16; // 8 bins/page in barrel, 16 in disks (may change in future)
+
 
 
 // Some functions
@@ -537,58 +539,6 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 	constexpr int nvmte = (Layer) ? nvmtelayers[Layer-1] : nvmtedisks[Disk-1]; // TE memories
 	constexpr int nvmol = ((Layer == 1) || (Layer == 2)) ? nvmteoverlaplayers[Layer-1] : 0; // TE Overlap memories
 
-
-	// Reset address counters in output memories
-	// Only clear if the masks says that memory is used
-	ALLSTUB_CLEAR:	for (int i = 0; i < MaxAllCopies; i++) {
-		#pragma HLS UNROLL
-		allStub[i].clear(bx);
-	}
-
-	if (memask) {
-		ME_CLEAR:	for (int i = 0; i < nvmme; i++) {
-			#pragma HLS UNROLL
-			if (memask[i + firstme]) meMemories[i].clear(bx);
-		}
-	}
-
-	if (teimask) {
-		TEI_CLEAR:	for (int i = 0; i < nvmte; i++) {
-			#pragma HLS UNROLL
-			if (teimask[i + firstte]) {
-				for (int j = 0; j < MaxTEICopies; j++) {
-					#pragma HLS UNROLL
-					teiMemories[i][j].clear(bx);
-				}
-			}
-		}
-	}
-
-	if (teomask) {
-		TEO_CLEAR:	for (int i = 0; i < nvmte; i++) {
-			#pragma HLS UNROLL
-			if (teomask[i + firstte]) {
-				for (int j = 0; j < MaxTEOCopies; j++) {
-					#pragma HLS UNROLL
-					teoMemories[i][j].clear(bx);
-				}
-			}
-		}
-	}
-
-	if (olmask) {
-	OL_CLEAR:	for (int i = 0; i < nvmol; i++) {
-			#pragma HLS UNROLL
-			if (olmask[i + firstol]) {
-				for (int j = 0; j < MaxOLCopies; j++) {
-					#pragma HLS UNROLL
-					olMemories[i][j].clear(bx);
-			}
-			}
-		}
-	}
-
-
 	// Number of data in each input memory
 
 	typename InputStubMemory<InType>::NEntryT ninputs[6]; // Array containing the number of inputs. Last two indices are for DISK2S
@@ -611,6 +561,18 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 	// Create variables that keep track of which memory address to read and write to
 
 	ap_uint<kNBits_MemAddr> read_addr(0); // Reading of input stubs
+	
+	int addrCountME[nvmme][nmaxbinsperpage]; // Writing of ME stubs
+	if (memask) {
+		#pragma HLS array_partition variable=addrCountME complete dim=0
+		ADDR_ME:	for (int i = 0; i < nvmme; i++) {
+			#pragma HLS UNROLL
+			for (int j = 0; j < nmaxbinsperpage; j++) {
+				#pragma HLS UNROLL
+					addrCountME[i][j]= 0;
+			}
+		}
+	}
 
 	int addrCountTEI[nvmte][MaxTEICopies]; // Writing of TE Inner stubs
 	if (teimask) {
@@ -624,6 +586,21 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 		}
 	}
 
+	int addrCountTEO[nvmte][MaxTEOCopies][nmaxbinsperpage]; // Writing of TE Outer stubs
+	if (teomask) {
+		#pragma HLS array_partition variable=addrCountTEO complete dim=0
+		ADDR_TEO:	for (int i = 0; i < nvmte; i++) {
+			#pragma HLS UNROLL
+			for (int j = 0; j < MaxTEOCopies; j++) {
+				#pragma HLS UNROLL
+				for (int k = 0; k < nmaxbinsperpage; k++) {
+					#pragma HLS UNROLL
+						addrCountTEO[i][j][k] = 0;
+				}
+			}
+		}
+	}
+
 	int addrCountOL[nvmol][MaxOLCopies]; // Writing of TE Overlap stubs
 	if (olmask) {
 	#pragma HLS array_partition variable=addrCountOL complete dim=0
@@ -631,7 +608,7 @@ void VMRouter(const BXType bx, const int finebintable[], const int phicorrtable[
 			#pragma HLS UNROLL
 			for (int j = 0; j < MaxOLCopies; j++) {
 				#pragma HLS UNROLL
-				addrCountOL[i][j] = 0;
+					addrCountOL[i][j] = 0;
 			}
 		}
 }
@@ -759,8 +736,10 @@ TOPLEVEL: for (auto i = 0; i < kMaxProc - (Layer ? kMaxProcOffset(module::VMR_LA
 		for (int n = 0; n < 32; n++) {
 			#pragma HLS UNROLL
 			if (memask[n]) {
-					if ((ivmMinus == n) || (ivmPlus == n))
-						meMemories[n-firstme].write_mem(bx, bin, stubme);
+					if ((ivmMinus == n) || (ivmPlus == n)) {
+						meMemories[n-firstme].write_mem(bx, bin, stubme, addrCountME[n-firstme][bin]);
+						addrCountME[n-firstme][bin] += 1; // Count the memory addresses we have written to
+					}
 				}
 			}
 		} // End ME memories
@@ -841,7 +820,8 @@ TOPLEVEL: for (auto i = 0; i < kMaxProc - (Layer ? kMaxProcOffset(module::VMR_LA
 					#pragma HLS UNROLL
 					bool passbend = bendoutertable[bendindex][stubte.getBend()]; // Check if stub passes bend cut
 					if (passbend) {
-						teoMemories[memindex][n].write_mem(bx, bin, stubte);
+						teoMemories[memindex][n].write_mem(bx, bin, stubte, addrCountTEO[memindex][n][bin]);
+						addrCountTEO[memindex][n][bin] += 1; // Count the memory addresses we have written to
 					}
 					bendindex++; // Use next bendcut table for the next memory "copy"
 				}


### PR DESCRIPTION
This PR removes the nentries ports for all the output memories for each of the HLS blocks. To test each module in HLS, the HLS test benches instead clear the full memory between each bunch crossing, and in the real FW system a signal in the top-level HDL will be sent to each memory at the end of each bx, telling the memory to set the relevant number of entries for the page to zero. More disussion can be found in issue #58, and in this talk https://indico.cern.ch/event/940922/contributions/3955291/attachments/2079826/3493207/HLSChat_nentries_2020-07-24.pdf

With this pull request (with the exception of MC, discussed below), the clock period and II achieved either stays the same or improves slightly, and the resource usage for each block goes down in every case (by a factor of ~2 for the VMR, modestly for the other blocks).

For the MC, before this PR we were sacrificing the first clock of the BX to zero the memories. Since we no longer have to do that, we now start the work of the MC on the first clock instead of the second. This change results in a change in the post-synthesis (post-implementation) timing from 2.84 (3.24) to 3.45 (3.56) ns. It's not clear why this is, but since the CP remains under our target even after the increase, I've left it as is.