### PR TITLE
Memory counter size

### DIFF
--- a/TrackletAlgorithm/MatchCalculator.h
+++ b/TrackletAlgorithm/MatchCalculator.h
@@ -392,14 +392,14 @@ void MatchCalculator(BXType bx,
   //-------------------------------- DATA PROCESSING STARTS ---------------------------------------------------
   //-----------------------------------------------------------------------------------------------------------
   // declare counters for each of the 8 output VMProj // !!!
-  int nmcout1 = 0;
-  int nmcout2 = 0;
-  int nmcout3 = 0;
-  int nmcout4 = 0;
-  int nmcout5 = 0;
-  int nmcout6 = 0;
-  int nmcout7 = 0;
-  int nmcout8 = 0;  
+  ap_uint<kNBits_MemAddr> nmcout1 = 0;
+  ap_uint<kNBits_MemAddr> nmcout2 = 0;
+  ap_uint<kNBits_MemAddr> nmcout3 = 0;
+  ap_uint<kNBits_MemAddr> nmcout4 = 0;
+  ap_uint<kNBits_MemAddr> nmcout5 = 0;
+  ap_uint<kNBits_MemAddr> nmcout6 = 0;
+  ap_uint<kNBits_MemAddr> nmcout7 = 0;
+  ap_uint<kNBits_MemAddr> nmcout8 = 0;  
   MC_LOOP: for (ap_uint<kNBits_MemAddr> istep = 0; istep < kMaxProc - kMaxProcOffset(module::MC); istep++)
   {
 

--- a/TrackletAlgorithm/MatchEngine.cc
+++ b/TrackletAlgorithm/MatchEngine.cc
@@ -60,7 +60,7 @@ void MatchEngine(const BXType bx, BXType& bx_o,
 	typename VMProjection<VMPMEType>::VMPFINEZ projfinez;
 	typename VMProjection<VMPMEType>::VMPRINV projrinv;
 	ap_uint<MEBinsBits> zbin = 0;
-	int ncmatch = 0;
+	ap_uint<kNBits_MemAddr> ncmatch = 0;
 	bool isPSseed;
 	bool second;
 

--- a/TrackletAlgorithm/TrackletCalculator.h
+++ b/TrackletAlgorithm/TrackletCalculator.h
@@ -127,7 +127,7 @@ namespace TC {
 
   template<TF::seed Seed, TC::itc iTC> const TrackletProjection<BARRELPS>::TProjTCID ID();
 
-  template<regionType TProjType, uint8_t NProjOut, uint32_t TPROJMask> bool addProj(const TrackletProjection<TProjType> &proj, const BXType bx, TrackletProjectionMemory<TProjType> projout[NProjOut], int nproj[NProjOut], const bool success);
+  template<regionType TProjType, uint8_t NProjOut, uint32_t TPROJMask> bool addProj(const TrackletProjection<TProjType> &proj, const BXType bx, TrackletProjectionMemory<TProjType> projout[NProjOut], ap_uint<kNBits_MemAddr> nproj[NProjOut], const bool success);
 
   template<uint8_t NSPMem> void
   getIndices(
@@ -151,10 +151,10 @@ namespace TC {
       TrackletProjectionMemory<BARRELPS> projout_barrel_ps[N_PROJOUT_BARRELPS],
       TrackletProjectionMemory<BARREL2S> projout_barrel_2s[N_PROJOUT_BARREL2S],
       TrackletProjectionMemory<DISK> projout_barrel_disk[N_PROJOUT_DISK],
-      int &npar,
-      int nproj_barrel_ps[N_PROJOUT_BARRELPS],
-      int nproj_barrel_2s[N_PROJOUT_BARREL2S],
-      int nproj_disk[N_PROJOUT_DISK]
+      ap_uint<kNBits_MemAddr> &npar,
+      ap_uint<kNBits_MemAddr> nproj_barrel_ps[N_PROJOUT_BARRELPS],
+      ap_uint<kNBits_MemAddr> nproj_barrel_2s[N_PROJOUT_BARREL2S],
+      ap_uint<kNBits_MemAddr> nproj_disk[N_PROJOUT_DISK]
   );
 }
 
@@ -364,7 +364,7 @@ TC::ID()
 
 // Writes a tracklet projection to the appropriate tracklet projection memory.
 template<regionType TProjType, uint8_t NProjOut, uint32_t TPROJMask> bool
-TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, TrackletProjectionMemory<TProjType> projout[NProjOut], int nproj[NProjOut], const bool success)
+TC::addProj(const TrackletProjection<TProjType> &proj, const BXType bx, TrackletProjectionMemory<TProjType> projout[NProjOut], ap_uint<kNBits_MemAddr> nproj[NProjOut], const bool success)
 {
   bool proj_success = true;
 
@@ -449,10 +449,10 @@ TC::processStubPair(
     TrackletProjectionMemory<BARRELPS> projout_barrel_ps[N_PROJOUT_BARRELPS],
     TrackletProjectionMemory<BARREL2S> projout_barrel_2s[N_PROJOUT_BARREL2S],
     TrackletProjectionMemory<DISK> projout_disk[N_PROJOUT_DISK],
-    int &npar,
-    int nproj_barrel_ps[N_PROJOUT_BARRELPS],
-    int nproj_barrel_2s[N_PROJOUT_BARREL2S],
-    int nproj_disk[N_PROJOUT_DISK]
+    ap_uint<kNBits_MemAddr> &npar,
+    ap_uint<kNBits_MemAddr> nproj_barrel_ps[N_PROJOUT_BARRELPS],
+    ap_uint<kNBits_MemAddr> nproj_barrel_2s[N_PROJOUT_BARREL2S],
+    ap_uint<kNBits_MemAddr> nproj_disk[N_PROJOUT_DISK]
 )
 {
   TC::Types::rinv rinv;
@@ -567,10 +567,10 @@ TrackletCalculator(
 {
   static_assert(Seed == TF::L1L2 || Seed == TF::L3L4 || Seed == TF::L5L6, "Only L1L2, L3L4, and L5L6 seeds have been implemented so far.");
 
-  int npar = 0;
-  int nproj_barrel_ps[TC::N_PROJOUT_BARRELPS];
-  int nproj_barrel_2s[TC::N_PROJOUT_BARREL2S];
-  int nproj_disk[TC::N_PROJOUT_DISK];
+  ap_uint<kNBits_MemAddr> npar = 0;
+  ap_uint<kNBits_MemAddr> nproj_barrel_ps[TC::N_PROJOUT_BARRELPS];
+  ap_uint<kNBits_MemAddr> nproj_barrel_2s[TC::N_PROJOUT_BARREL2S];
+  ap_uint<kNBits_MemAddr> nproj_disk[TC::N_PROJOUT_DISK];
 #pragma HLS array_partition variable=nproj_barrel_ps complete
 #pragma HLS array_partition variable=nproj_barrel_2s complete
 #pragma HLS array_partition variable=nproj_disk complete

--- a/TrackletAlgorithm/TrackletEngine.h
+++ b/TrackletAlgorithm/TrackletEngine.h
@@ -49,7 +49,7 @@ void TrackletEngine(
 		    StubPairMemory& outstubpair) {
 
 #pragma HLS inline
-  int nstubpairs = 0;
+  ap_uint<kNBits_MemAddr> nstubpairs = 0;
 #pragma HLS dependence variable=nstubpairs intra WAR true
 
   //


### PR DESCRIPTION
I switched the few `int` memory counters remaining to `ap_uint<kNBits_MemAddr>`. This has a positive impact on the resource utilization reported by HLS for the affected modules, especially the TC and MC:
| Module | Change in FF utilization | Change in LUT utilization |
| --- | --- | --- |
| TE | -2% | -1% |
| TC | -7% | -17% |
| ME | -2% | -2% |
| MC | -13% | -7% |